### PR TITLE
Run Airseeker, signed APIs and Pushers on AWS with Polygon testnet

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -25,4 +25,4 @@
 **/artifacts
 **/coverage.json
 **/typechain
-**/typechain-types
+# **/typechain-types TODO: Re-enable

--- a/.dockerignore
+++ b/.dockerignore
@@ -25,4 +25,4 @@
 **/artifacts
 **/coverage.json
 **/typechain
-# **/typechain-types TODO: Re-enable
+# **/typechain-types NOTE: Disabled in order to build the docker image locally on macOS.

--- a/local-test-configuration/airseeker/airseeker.example.json
+++ b/local-test-configuration/airseeker/airseeker.example.json
@@ -7,8 +7,8 @@
         "DapiDataRegistry": "${DAPI_DATA_REGISTRY_ADDRESS}"
       },
       "providers": {
-        "hardhat": {
-          "url": "http://${LOCALHOST_IP}:8545"
+        "polygon-testnet": {
+          "url": "https://polygon-mumbai-bor.publicnode.com"
         }
       },
       "gasSettings": {

--- a/local-test-configuration/polygon-deployments/airseeker-cf.json
+++ b/local-test-configuration/polygon-deployments/airseeker-cf.json
@@ -1,0 +1,211 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "A CloudFormation template for deploying the Airseeker v2 on AWS",
+  "Parameters": {
+    "sponsorWalletMnemonic": {
+      "Type": "String",
+      "MinLength": 10,
+      "Description": "Mnemonic phrase of your Airseeker used to derive sponsor wallets"
+    }
+  },
+  "Resources": {
+    "CloudWatchLogsGroup": {
+      "Type": "AWS::Logs::LogGroup",
+      "Properties": {
+        "LogGroupName": "AirseekerLogGroup",
+        "RetentionInDays": 7
+      }
+    },
+    "AppDefinition": {
+      "Type": "AWS::ECS::TaskDefinition",
+      "Properties": {
+        "NetworkMode": "awsvpc",
+        "Cpu": 256,
+        "Memory": 512,
+        "ExecutionRoleArn": {
+          "Ref": "ECSTaskRole"
+        },
+        "RequiresCompatibilities": ["FARGATE"],
+        "ContainerDefinitions": [
+          {
+            "Name": "Airseeker-a1369a2f2e8fe6af191b667478fcac1112672b35",
+            "Image": "siegrift/api3-airseeker-v2:a1369a2f2e8fe6af191b667478fcac1112672b35",
+            "Environment": [
+              {
+                "Name": "SECRETS_ENV",
+                "Value": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "SPONSOR_WALLET_MNEMONIC",
+                      "=",
+                      { "Ref": "sponsorWalletMnemonic" },
+                      "\\n",
+                      "API3_SERVER_V1_ADDRESS",
+                      "=",
+                      "0x9A0F9f6dE89BE3D155483A469a5feB2eE875fB5F",
+                      "\\n",
+                      "DAPI_DATA_REGISTRY_ADDRESS",
+                      "=",
+                      "0xb062aE0e1bBf6E2D1a9eA6e5750357979eA8A3f6"
+                    ]
+                  ]
+                }
+              },
+              {
+                "Name": "LOG_LEVEL",
+                "Value": "debug"
+              }
+            ],
+            "EntryPoint": [
+              "/bin/sh",
+              "-c",
+              "echo -e $SECRETS_ENV >> ./config/secrets.env && wget -O - https://raw.githubusercontent.com/api3dao/airseeker-v2/polygon-aws/local-test-configuration/airseeker/airseeker.example.json >> ./config/airseeker.json && node dist/index.js"
+            ],
+            "LogConfiguration": {
+              "LogDriver": "awslogs",
+              "Options": {
+                "awslogs-group": {
+                  "Ref": "CloudWatchLogsGroup"
+                },
+                "awslogs-region": {
+                  "Ref": "AWS::Region"
+                },
+                "awslogs-stream-prefix": "siegrift-airseeker-1700482577"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "AppCluster": {
+      "Type": "AWS::ECS::Cluster",
+      "Properties": {
+        "ClusterName": "AirseekerCluster-1700482577"
+      }
+    },
+    "AppService": {
+      "Type": "AWS::ECS::Service",
+      "Properties": {
+        "Cluster": {
+          "Ref": "AppCluster"
+        },
+        "ServiceName": "AirseekerService",
+        "DesiredCount": 1,
+        "LaunchType": "FARGATE",
+        "TaskDefinition": {
+          "Ref": "AppDefinition"
+        },
+        "NetworkConfiguration": {
+          "AwsvpcConfiguration": {
+            "AssignPublicIp": "ENABLED",
+            "Subnets": [
+              {
+                "Ref": "InstanceSubnet"
+              }
+            ]
+          }
+        },
+        "DeploymentConfiguration": {
+          "MinimumHealthyPercent": 100,
+          "MaximumPercent": 200
+        }
+      }
+    },
+    "InstanceVPC": {
+      "Type": "AWS::EC2::VPC",
+      "Properties": {
+        "CidrBlock": "10.0.0.0/16",
+        "EnableDnsSupport": true,
+        "EnableDnsHostnames": true
+      }
+    },
+    "InstanceInternetGateway": {
+      "Type": "AWS::EC2::InternetGateway"
+    },
+    "InstanceVPCGatewayAttachment": {
+      "Type": "AWS::EC2::VPCGatewayAttachment",
+      "Properties": {
+        "VpcId": {
+          "Ref": "InstanceVPC"
+        },
+        "InternetGatewayId": {
+          "Ref": "InstanceInternetGateway"
+        }
+      }
+    },
+    "InstancePublicRouteTable": {
+      "Type": "AWS::EC2::RouteTable",
+      "Properties": {
+        "VpcId": {
+          "Ref": "InstanceVPC"
+        }
+      }
+    },
+    "InstancePublicRoute": {
+      "Type": "AWS::EC2::Route",
+      "DependsOn": "InstanceVPCGatewayAttachment",
+      "Properties": {
+        "RouteTableId": {
+          "Ref": "InstancePublicRouteTable"
+        },
+        "DestinationCidrBlock": "0.0.0.0/0",
+        "GatewayId": {
+          "Ref": "InstanceInternetGateway"
+        }
+      }
+    },
+    "InstanceSubnet": {
+      "Type": "AWS::EC2::Subnet",
+      "Properties": {
+        "CidrBlock": "10.0.0.0/24",
+        "VpcId": {
+          "Ref": "InstanceVPC"
+        },
+        "MapPublicIpOnLaunch": true
+      }
+    },
+    "InstancePublicSubnet1RouteTableAssociation": {
+      "Type": "AWS::EC2::SubnetRouteTableAssociation",
+      "Properties": {
+        "RouteTableId": {
+          "Ref": "InstancePublicRouteTable"
+        },
+        "SubnetId": {
+          "Ref": "InstanceSubnet"
+        }
+      }
+    },
+    "ECSTaskRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": {
+            "Effect": "Allow",
+            "Principal": {
+              "Service": ["ecs-tasks.amazonaws.com"]
+            },
+            "Action": ["sts:AssumeRole"]
+          }
+        },
+        "Policies": [
+          {
+            "PolicyName": "ECSTaskExecutionRolePolicy",
+            "PolicyDocument": {
+              "Statement": {
+                "Effect": "Allow",
+                "Action": [
+                  "logs:CreateLogGroup",
+                  "logs:CreateLogStream",
+                  "logs:DescribeLogStreams",
+                  "logs:PutLogEvents"
+                ],
+                "Resource": "*"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/local-test-configuration/polygon-deployments/pusher-1-cf.json
+++ b/local-test-configuration/polygon-deployments/pusher-1-cf.json
@@ -1,0 +1,220 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "A CloudFormation template for deploying the Pusher on AWS.",
+  "Parameters": {
+    "airnodeMnemonic": {
+      "Type": "String",
+      "MinLength": 10,
+      "Description": "Mnemonic phrase of your Airnode address."
+    },
+    "nodaryApiKey": {
+      "Type": "String",
+      "MinLength": 10,
+      "Description": "Nodary API key."
+    }
+  },
+  "Resources": {
+    "CloudWatchLogsGroup": {
+      "Type": "AWS::Logs::LogGroup",
+      "Properties": {
+        "LogGroupName": "PusherLogGroup",
+        "RetentionInDays": 7
+      }
+    },
+    "AppDefinition": {
+      "Type": "AWS::ECS::TaskDefinition",
+      "Properties": {
+        "NetworkMode": "awsvpc",
+        "Cpu": 256,
+        "Memory": 512,
+        "ExecutionRoleArn": {
+          "Ref": "ECSTaskRole"
+        },
+        "RequiresCompatibilities": ["FARGATE"],
+        "ContainerDefinitions": [
+          {
+            "Name": "Pusher-8feb122755282d6450e5529205e5ad8565d35f33",
+            "Image": "siegrift/api3-pusher:8feb122755282d6450e5529205e5ad8565d35f33",
+            "Environment": [
+              {
+                "Name": "SECRETS_ENV",
+                "Value": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "WALLET_MNEMONIC",
+                      "=",
+                      {
+                        "Ref": "airnodeMnemonic"
+                      },
+                      "\\n",
+                      "NODARY_API_KEY",
+                      "=",
+                      {
+                        "Ref": "nodaryApiKey"
+                      },
+                      "\\n",
+                      "STAGE",
+                      "=",
+                      "aws-1700482577"
+                    ]
+                  ]
+                }
+              },
+              {
+                "Name": "LOG_LEVEL",
+                "Value": "debug"
+              }
+            ],
+            "EntryPoint": [
+              "/bin/sh",
+              "-c",
+              "echo -e $SECRETS_ENV >> ./config/secrets.env && wget -O - https://raw.githubusercontent.com/api3dao/airseeker-v2/polygon-aws/local-test-configuration/pusher-1/pusher.json >> ./config/pusher.json && node dist/src/index.js"
+            ],
+            "LogConfiguration": {
+              "LogDriver": "awslogs",
+              "Options": {
+                "awslogs-group": {
+                  "Ref": "CloudWatchLogsGroup"
+                },
+                "awslogs-region": {
+                  "Ref": "AWS::Region"
+                },
+                "awslogs-stream-prefix": "siegrift-pusher-1700482577"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "AppCluster": {
+      "Type": "AWS::ECS::Cluster",
+      "Properties": {
+        "ClusterName": "PusherCluster-1700482577"
+      }
+    },
+    "AppService": {
+      "Type": "AWS::ECS::Service",
+      "Properties": {
+        "Cluster": {
+          "Ref": "AppCluster"
+        },
+        "ServiceName": "PusherService",
+        "DesiredCount": 1,
+        "LaunchType": "FARGATE",
+        "TaskDefinition": {
+          "Ref": "AppDefinition"
+        },
+        "NetworkConfiguration": {
+          "AwsvpcConfiguration": {
+            "AssignPublicIp": "ENABLED",
+            "Subnets": [
+              {
+                "Ref": "InstanceSubnet"
+              }
+            ]
+          }
+        },
+        "DeploymentConfiguration": {
+          "MinimumHealthyPercent": 100,
+          "MaximumPercent": 200
+        }
+      }
+    },
+    "InstanceVPC": {
+      "Type": "AWS::EC2::VPC",
+      "Properties": {
+        "CidrBlock": "10.0.0.0/16",
+        "EnableDnsSupport": true,
+        "EnableDnsHostnames": true
+      }
+    },
+    "InstanceInternetGateway": {
+      "Type": "AWS::EC2::InternetGateway"
+    },
+    "InstanceVPCGatewayAttachment": {
+      "Type": "AWS::EC2::VPCGatewayAttachment",
+      "Properties": {
+        "VpcId": {
+          "Ref": "InstanceVPC"
+        },
+        "InternetGatewayId": {
+          "Ref": "InstanceInternetGateway"
+        }
+      }
+    },
+    "InstancePublicRouteTable": {
+      "Type": "AWS::EC2::RouteTable",
+      "Properties": {
+        "VpcId": {
+          "Ref": "InstanceVPC"
+        }
+      }
+    },
+    "InstancePublicRoute": {
+      "Type": "AWS::EC2::Route",
+      "DependsOn": "InstanceVPCGatewayAttachment",
+      "Properties": {
+        "RouteTableId": {
+          "Ref": "InstancePublicRouteTable"
+        },
+        "DestinationCidrBlock": "0.0.0.0/0",
+        "GatewayId": {
+          "Ref": "InstanceInternetGateway"
+        }
+      }
+    },
+    "InstanceSubnet": {
+      "Type": "AWS::EC2::Subnet",
+      "Properties": {
+        "CidrBlock": "10.0.0.0/24",
+        "VpcId": {
+          "Ref": "InstanceVPC"
+        },
+        "MapPublicIpOnLaunch": true
+      }
+    },
+    "InstancePublicSubnet1RouteTableAssociation": {
+      "Type": "AWS::EC2::SubnetRouteTableAssociation",
+      "Properties": {
+        "RouteTableId": {
+          "Ref": "InstancePublicRouteTable"
+        },
+        "SubnetId": {
+          "Ref": "InstanceSubnet"
+        }
+      }
+    },
+    "ECSTaskRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": {
+            "Effect": "Allow",
+            "Principal": {
+              "Service": ["ecs-tasks.amazonaws.com"]
+            },
+            "Action": ["sts:AssumeRole"]
+          }
+        },
+        "Policies": [
+          {
+            "PolicyName": "ECSTaskExecutionRolePolicy",
+            "PolicyDocument": {
+              "Statement": {
+                "Effect": "Allow",
+                "Action": [
+                  "logs:CreateLogGroup",
+                  "logs:CreateLogStream",
+                  "logs:DescribeLogStreams",
+                  "logs:PutLogEvents"
+                ],
+                "Resource": "*"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/local-test-configuration/polygon-deployments/pusher-1-cf.json
+++ b/local-test-configuration/polygon-deployments/pusher-1-cf.json
@@ -17,7 +17,7 @@
     "CloudWatchLogsGroup": {
       "Type": "AWS::Logs::LogGroup",
       "Properties": {
-        "LogGroupName": "PusherLogGroup",
+        "LogGroupName": "PusherLogGroup-id-1700482577",
         "RetentionInDays": 7
       }
     },

--- a/local-test-configuration/polygon-deployments/pusher-2-cf.json
+++ b/local-test-configuration/polygon-deployments/pusher-2-cf.json
@@ -1,0 +1,220 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "A CloudFormation template for deploying the Pusher on AWS.",
+  "Parameters": {
+    "airnodeMnemonic": {
+      "Type": "String",
+      "MinLength": 10,
+      "Description": "Mnemonic phrase of your Airnode address."
+    },
+    "nodaryApiKey": {
+      "Type": "String",
+      "MinLength": 10,
+      "Description": "Nodary API key."
+    }
+  },
+  "Resources": {
+    "CloudWatchLogsGroup": {
+      "Type": "AWS::Logs::LogGroup",
+      "Properties": {
+        "LogGroupName": "PusherLogGroup",
+        "RetentionInDays": 7
+      }
+    },
+    "AppDefinition": {
+      "Type": "AWS::ECS::TaskDefinition",
+      "Properties": {
+        "NetworkMode": "awsvpc",
+        "Cpu": 256,
+        "Memory": 512,
+        "ExecutionRoleArn": {
+          "Ref": "ECSTaskRole"
+        },
+        "RequiresCompatibilities": ["FARGATE"],
+        "ContainerDefinitions": [
+          {
+            "Name": "Pusher-8feb122755282d6450e5529205e5ad8565d35f33",
+            "Image": "siegrift/api3-pusher:8feb122755282d6450e5529205e5ad8565d35f33",
+            "Environment": [
+              {
+                "Name": "SECRETS_ENV",
+                "Value": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "WALLET_MNEMONIC",
+                      "=",
+                      {
+                        "Ref": "airnodeMnemonic"
+                      },
+                      "\\n",
+                      "NODARY_API_KEY",
+                      "=",
+                      {
+                        "Ref": "nodaryApiKey"
+                      },
+                      "\\n",
+                      "STAGE",
+                      "=",
+                      "aws-1700662735"
+                    ]
+                  ]
+                }
+              },
+              {
+                "Name": "LOG_LEVEL",
+                "Value": "debug"
+              }
+            ],
+            "EntryPoint": [
+              "/bin/sh",
+              "-c",
+              "echo -e $SECRETS_ENV >> ./config/secrets.env && wget -O - https://raw.githubusercontent.com/api3dao/airseeker-v2/polygon-aws/local-test-configuration/pusher-2/pusher.json >> ./config/pusher.json && node dist/src/index.js"
+            ],
+            "LogConfiguration": {
+              "LogDriver": "awslogs",
+              "Options": {
+                "awslogs-group": {
+                  "Ref": "CloudWatchLogsGroup"
+                },
+                "awslogs-region": {
+                  "Ref": "AWS::Region"
+                },
+                "awslogs-stream-prefix": "siegrift-pusher-1700662735"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "AppCluster": {
+      "Type": "AWS::ECS::Cluster",
+      "Properties": {
+        "ClusterName": "PusherCluster-1700662735"
+      }
+    },
+    "AppService": {
+      "Type": "AWS::ECS::Service",
+      "Properties": {
+        "Cluster": {
+          "Ref": "AppCluster"
+        },
+        "ServiceName": "PusherService",
+        "DesiredCount": 1,
+        "LaunchType": "FARGATE",
+        "TaskDefinition": {
+          "Ref": "AppDefinition"
+        },
+        "NetworkConfiguration": {
+          "AwsvpcConfiguration": {
+            "AssignPublicIp": "ENABLED",
+            "Subnets": [
+              {
+                "Ref": "InstanceSubnet"
+              }
+            ]
+          }
+        },
+        "DeploymentConfiguration": {
+          "MinimumHealthyPercent": 100,
+          "MaximumPercent": 200
+        }
+      }
+    },
+    "InstanceVPC": {
+      "Type": "AWS::EC2::VPC",
+      "Properties": {
+        "CidrBlock": "10.0.0.0/16",
+        "EnableDnsSupport": true,
+        "EnableDnsHostnames": true
+      }
+    },
+    "InstanceInternetGateway": {
+      "Type": "AWS::EC2::InternetGateway"
+    },
+    "InstanceVPCGatewayAttachment": {
+      "Type": "AWS::EC2::VPCGatewayAttachment",
+      "Properties": {
+        "VpcId": {
+          "Ref": "InstanceVPC"
+        },
+        "InternetGatewayId": {
+          "Ref": "InstanceInternetGateway"
+        }
+      }
+    },
+    "InstancePublicRouteTable": {
+      "Type": "AWS::EC2::RouteTable",
+      "Properties": {
+        "VpcId": {
+          "Ref": "InstanceVPC"
+        }
+      }
+    },
+    "InstancePublicRoute": {
+      "Type": "AWS::EC2::Route",
+      "DependsOn": "InstanceVPCGatewayAttachment",
+      "Properties": {
+        "RouteTableId": {
+          "Ref": "InstancePublicRouteTable"
+        },
+        "DestinationCidrBlock": "0.0.0.0/0",
+        "GatewayId": {
+          "Ref": "InstanceInternetGateway"
+        }
+      }
+    },
+    "InstanceSubnet": {
+      "Type": "AWS::EC2::Subnet",
+      "Properties": {
+        "CidrBlock": "10.0.0.0/24",
+        "VpcId": {
+          "Ref": "InstanceVPC"
+        },
+        "MapPublicIpOnLaunch": true
+      }
+    },
+    "InstancePublicSubnet1RouteTableAssociation": {
+      "Type": "AWS::EC2::SubnetRouteTableAssociation",
+      "Properties": {
+        "RouteTableId": {
+          "Ref": "InstancePublicRouteTable"
+        },
+        "SubnetId": {
+          "Ref": "InstanceSubnet"
+        }
+      }
+    },
+    "ECSTaskRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": {
+            "Effect": "Allow",
+            "Principal": {
+              "Service": ["ecs-tasks.amazonaws.com"]
+            },
+            "Action": ["sts:AssumeRole"]
+          }
+        },
+        "Policies": [
+          {
+            "PolicyName": "ECSTaskExecutionRolePolicy",
+            "PolicyDocument": {
+              "Statement": {
+                "Effect": "Allow",
+                "Action": [
+                  "logs:CreateLogGroup",
+                  "logs:CreateLogStream",
+                  "logs:DescribeLogStreams",
+                  "logs:PutLogEvents"
+                ],
+                "Resource": "*"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/local-test-configuration/polygon-deployments/pusher-2-cf.json
+++ b/local-test-configuration/polygon-deployments/pusher-2-cf.json
@@ -17,7 +17,7 @@
     "CloudWatchLogsGroup": {
       "Type": "AWS::Logs::LogGroup",
       "Properties": {
-        "LogGroupName": "PusherLogGroup",
+        "LogGroupName": "PusherLogGroup-1700662735",
         "RetentionInDays": 7
       }
     },

--- a/local-test-configuration/polygon-deployments/signed-api-1-cf.json
+++ b/local-test-configuration/polygon-deployments/signed-api-1-cf.json
@@ -1,0 +1,272 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "CloudFormation template for deploying Signed API with public access",
+  "Outputs": {
+    "LoadBalancerDNS": {
+      "Description": "The DNS name of the load balancer",
+      "Value": { "Fn::GetAtt": ["ELB", "DNSName"] },
+      "Export": {
+        "Name": { "Fn::Sub": "${AWS::StackName}-LoadBalancerDNS" }
+      }
+    }
+  },
+  "Resources": {
+    "SignedApiLogsGroup": {
+      "Type": "AWS::Logs::LogGroup",
+      "Properties": {
+        "LogGroupName": "/ecs/signedApi-id-1",
+        "RetentionInDays": 7
+      }
+    },
+    "SignedApiTaskDefinition": {
+      "Type": "AWS::ECS::TaskDefinition",
+      "Properties": {
+        "Family": "signed-api-task",
+        "Cpu": "256",
+        "Memory": "512",
+        "NetworkMode": "awsvpc",
+        "RequiresCompatibilities": ["FARGATE"],
+        "ExecutionRoleArn": { "Ref": "ECSTaskRole" },
+        "ContainerDefinitions": [
+          {
+            "Name": "signed-api-container",
+            "Image": "siegrift/api3-signed-api:8feb122755282d6450e5529205e5ad8565d35f33",
+            "Environment": [
+              {
+                "Name": "CONFIG_SOURCE",
+                "Value": "local"
+              },
+              {
+                "Name": "LOG_LEVEL",
+                "Value": "debug"
+              }
+            ],
+            "EntryPoint": [
+              "/bin/sh",
+              "-c",
+              "wget -O - https://raw.githubusercontent.com/api3dao/airseeker-v2/polygon-aws/local-test-configuration/signed-api-1/signed-api.json >> ./config/signed-api.json && node dist/index.js"
+            ],
+            "PortMappings": [
+              {
+                "ContainerPort": 80,
+                "HostPort": 80
+              }
+            ],
+            "LogConfiguration": {
+              "LogDriver": "awslogs",
+              "Options": {
+                "awslogs-group": { "Ref": "SignedApiLogsGroup" },
+                "awslogs-region": { "Ref": "AWS::Region" },
+                "awslogs-stream-prefix": "ecs"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "SignedApiService": {
+      "Type": "AWS::ECS::Service",
+      "DependsOn": "SignedApiListener",
+      "Properties": {
+        "Cluster": { "Ref": "ECSCluster" },
+        "LaunchType": "FARGATE",
+        "TaskDefinition": { "Ref": "SignedApiTaskDefinition" },
+        "DesiredCount": 1,
+        "NetworkConfiguration": {
+          "AwsvpcConfiguration": {
+            "Subnets": [{ "Ref": "PublicSubnet1" }, { "Ref": "PublicSubnet2" }],
+            "SecurityGroups": [{ "Ref": "ECSSecurityGroup" }],
+            "AssignPublicIp": "ENABLED"
+          }
+        },
+        "LoadBalancers": [
+          {
+            "ContainerName": "signed-api-container",
+            "ContainerPort": 80,
+            "TargetGroupArn": { "Ref": "SignedApiTargetGroup" }
+          }
+        ]
+      }
+    },
+    "ECSCluster": {
+      "Type": "AWS::ECS::Cluster",
+      "Properties": {
+        "ClusterName": "signed-api-cluster-id-1"
+      }
+    },
+    "ELB": {
+      "Type": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "Properties": {
+        "Name": "signed-api-elb-id-1",
+        "Subnets": [{ "Ref": "PublicSubnet1" }, { "Ref": "PublicSubnet2" }],
+        "SecurityGroups": [{ "Ref": "ELBSecurityGroup" }],
+        "Scheme": "internet-facing"
+      }
+    },
+    "SignedApiListener": {
+      "Type": "AWS::ElasticLoadBalancingV2::Listener",
+      "Properties": {
+        "DefaultActions": [
+          {
+            "Type": "forward",
+            "TargetGroupArn": { "Ref": "SignedApiTargetGroup" }
+          }
+        ],
+        "LoadBalancerArn": { "Ref": "ELB" },
+        "Port": 80,
+        "Protocol": "HTTP"
+      }
+    },
+    "SignedApiTargetGroup": {
+      "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "Properties": {
+        "Port": 80,
+        "Protocol": "HTTP",
+        "VpcId": { "Ref": "VPC" },
+        "TargetType": "ip"
+      }
+    },
+    "VPC": {
+      "Type": "AWS::EC2::VPC",
+      "Properties": {
+        "CidrBlock": "10.0.0.0/16",
+        "EnableDnsSupport": "true",
+        "EnableDnsHostnames": "true"
+      }
+    },
+    "PublicSubnet1": {
+      "Type": "AWS::EC2::Subnet",
+      "Properties": {
+        "VpcId": { "Ref": "VPC" },
+        "CidrBlock": "10.0.1.0/24",
+        "AvailabilityZone": { "Fn::Select": [0, { "Fn::GetAZs": "" }] },
+        "MapPublicIpOnLaunch": "true"
+      }
+    },
+    "PublicSubnet2": {
+      "Type": "AWS::EC2::Subnet",
+      "Properties": {
+        "VpcId": { "Ref": "VPC" },
+        "CidrBlock": "10.0.2.0/24",
+        "AvailabilityZone": { "Fn::Select": [1, { "Fn::GetAZs": "" }] },
+        "MapPublicIpOnLaunch": "true"
+      }
+    },
+    "InternetGateway": {
+      "Type": "AWS::EC2::InternetGateway"
+    },
+    "GatewayAttachment": {
+      "Type": "AWS::EC2::VPCGatewayAttachment",
+      "Properties": {
+        "VpcId": { "Ref": "VPC" },
+        "InternetGatewayId": { "Ref": "InternetGateway" }
+      }
+    },
+    "RouteTable": {
+      "Type": "AWS::EC2::RouteTable",
+      "Properties": {
+        "VpcId": { "Ref": "VPC" }
+      }
+    },
+    "Route": {
+      "Type": "AWS::EC2::Route",
+      "DependsOn": "GatewayAttachment",
+      "Properties": {
+        "RouteTableId": { "Ref": "RouteTable" },
+        "DestinationCidrBlock": "0.0.0.0/0",
+        "GatewayId": { "Ref": "InternetGateway" }
+      }
+    },
+    "Subnet1RouteTableAssociation": {
+      "Type": "AWS::EC2::SubnetRouteTableAssociation",
+      "Properties": {
+        "SubnetId": { "Ref": "PublicSubnet1" },
+        "RouteTableId": { "Ref": "RouteTable" }
+      }
+    },
+    "Subnet2RouteTableAssociation": {
+      "Type": "AWS::EC2::SubnetRouteTableAssociation",
+      "Properties": {
+        "SubnetId": { "Ref": "PublicSubnet2" },
+        "RouteTableId": { "Ref": "RouteTable" }
+      }
+    },
+    "ECSSecurityGroup": {
+      "Type": "AWS::EC2::SecurityGroup",
+      "Properties": {
+        "GroupDescription": "Security Group for ECS Tasks",
+        "VpcId": { "Ref": "VPC" },
+        "SecurityGroupIngress": [
+          {
+            "IpProtocol": "tcp",
+            "FromPort": 80,
+            "ToPort": 80,
+            "SourceSecurityGroupId": { "Ref": "ELBSecurityGroup" }
+          }
+        ]
+      }
+    },
+    "ELBSecurityGroup": {
+      "Type": "AWS::EC2::SecurityGroup",
+      "Properties": {
+        "GroupDescription": "Security Group for ELB",
+        "VpcId": { "Ref": "VPC" },
+        "SecurityGroupIngress": [
+          {
+            "IpProtocol": "tcp",
+            "FromPort": 80,
+            "ToPort": 80,
+            "CidrIp": "0.0.0.0/0"
+          }
+        ]
+      }
+    },
+    "ECSTaskRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Principal": {
+                "Service": ["ecs-tasks.amazonaws.com"]
+              },
+              "Action": ["sts:AssumeRole"]
+            }
+          ]
+        },
+        "Path": "/",
+        "Policies": [
+          {
+            "PolicyName": "ecs-service",
+            "PolicyDocument": {
+              "Version": "2012-10-17",
+              "Statement": [
+                {
+                  "Effect": "Allow",
+                  "Action": [
+                    "ec2:AuthorizeSecurityGroupIngress",
+                    "ec2:Describe*",
+                    "elasticloadbalancing:DeregisterInstancesFromLoadBalancer",
+                    "elasticloadbalancing:DeregisterTargets",
+                    "elasticloadbalancing:Describe*",
+                    "elasticloadbalancing:RegisterInstancesWithLoadBalancer",
+                    "elasticloadbalancing:RegisterTargets",
+                    "ec2:CreateSecurityGroup",
+                    "ec2:DeleteSecurityGroup",
+                    "logs:CreateLogGroup",
+                    "logs:CreateLogStream",
+                    "logs:DescribeLogStreams",
+                    "logs:PutLogEvents"
+                  ],
+                  "Resource": "*"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/local-test-configuration/polygon-deployments/signed-api-2-cf.json
+++ b/local-test-configuration/polygon-deployments/signed-api-2-cf.json
@@ -1,0 +1,272 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "CloudFormation template for deploying Signed API with public access",
+  "Outputs": {
+    "LoadBalancerDNS": {
+      "Description": "The DNS name of the load balancer",
+      "Value": { "Fn::GetAtt": ["ELB", "DNSName"] },
+      "Export": {
+        "Name": { "Fn::Sub": "${AWS::StackName}-LoadBalancerDNS" }
+      }
+    }
+  },
+  "Resources": {
+    "SignedApiLogsGroup": {
+      "Type": "AWS::Logs::LogGroup",
+      "Properties": {
+        "LogGroupName": "/ecs/signedApi-id-2",
+        "RetentionInDays": 7
+      }
+    },
+    "SignedApiTaskDefinition": {
+      "Type": "AWS::ECS::TaskDefinition",
+      "Properties": {
+        "Family": "signed-api-task",
+        "Cpu": "256",
+        "Memory": "512",
+        "NetworkMode": "awsvpc",
+        "RequiresCompatibilities": ["FARGATE"],
+        "ExecutionRoleArn": { "Ref": "ECSTaskRole" },
+        "ContainerDefinitions": [
+          {
+            "Name": "signed-api-container",
+            "Image": "siegrift/api3-signed-api:8feb122755282d6450e5529205e5ad8565d35f33",
+            "Environment": [
+              {
+                "Name": "CONFIG_SOURCE",
+                "Value": "local"
+              },
+              {
+                "Name": "LOG_LEVEL",
+                "Value": "debug"
+              }
+            ],
+            "EntryPoint": [
+              "/bin/sh",
+              "-c",
+              "wget -O - https://raw.githubusercontent.com/api3dao/airseeker-v2/polygon-aws/local-test-configuration/signed-api-2/signed-api.json >> ./config/signed-api.json && node dist/index.js"
+            ],
+            "PortMappings": [
+              {
+                "ContainerPort": 80,
+                "HostPort": 80
+              }
+            ],
+            "LogConfiguration": {
+              "LogDriver": "awslogs",
+              "Options": {
+                "awslogs-group": { "Ref": "SignedApiLogsGroup" },
+                "awslogs-region": { "Ref": "AWS::Region" },
+                "awslogs-stream-prefix": "ecs"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "SignedApiService": {
+      "Type": "AWS::ECS::Service",
+      "DependsOn": "SignedApiListener",
+      "Properties": {
+        "Cluster": { "Ref": "ECSCluster" },
+        "LaunchType": "FARGATE",
+        "TaskDefinition": { "Ref": "SignedApiTaskDefinition" },
+        "DesiredCount": 1,
+        "NetworkConfiguration": {
+          "AwsvpcConfiguration": {
+            "Subnets": [{ "Ref": "PublicSubnet1" }, { "Ref": "PublicSubnet2" }],
+            "SecurityGroups": [{ "Ref": "ECSSecurityGroup" }],
+            "AssignPublicIp": "ENABLED"
+          }
+        },
+        "LoadBalancers": [
+          {
+            "ContainerName": "signed-api-container",
+            "ContainerPort": 80,
+            "TargetGroupArn": { "Ref": "SignedApiTargetGroup" }
+          }
+        ]
+      }
+    },
+    "ECSCluster": {
+      "Type": "AWS::ECS::Cluster",
+      "Properties": {
+        "ClusterName": "signed-api-cluster-id-2"
+      }
+    },
+    "ELB": {
+      "Type": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "Properties": {
+        "Name": "signed-api-elb-id-2",
+        "Subnets": [{ "Ref": "PublicSubnet1" }, { "Ref": "PublicSubnet2" }],
+        "SecurityGroups": [{ "Ref": "ELBSecurityGroup" }],
+        "Scheme": "internet-facing"
+      }
+    },
+    "SignedApiListener": {
+      "Type": "AWS::ElasticLoadBalancingV2::Listener",
+      "Properties": {
+        "DefaultActions": [
+          {
+            "Type": "forward",
+            "TargetGroupArn": { "Ref": "SignedApiTargetGroup" }
+          }
+        ],
+        "LoadBalancerArn": { "Ref": "ELB" },
+        "Port": 80,
+        "Protocol": "HTTP"
+      }
+    },
+    "SignedApiTargetGroup": {
+      "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "Properties": {
+        "Port": 80,
+        "Protocol": "HTTP",
+        "VpcId": { "Ref": "VPC" },
+        "TargetType": "ip"
+      }
+    },
+    "VPC": {
+      "Type": "AWS::EC2::VPC",
+      "Properties": {
+        "CidrBlock": "10.0.0.0/16",
+        "EnableDnsSupport": "true",
+        "EnableDnsHostnames": "true"
+      }
+    },
+    "PublicSubnet1": {
+      "Type": "AWS::EC2::Subnet",
+      "Properties": {
+        "VpcId": { "Ref": "VPC" },
+        "CidrBlock": "10.0.1.0/24",
+        "AvailabilityZone": { "Fn::Select": [0, { "Fn::GetAZs": "" }] },
+        "MapPublicIpOnLaunch": "true"
+      }
+    },
+    "PublicSubnet2": {
+      "Type": "AWS::EC2::Subnet",
+      "Properties": {
+        "VpcId": { "Ref": "VPC" },
+        "CidrBlock": "10.0.2.0/24",
+        "AvailabilityZone": { "Fn::Select": [1, { "Fn::GetAZs": "" }] },
+        "MapPublicIpOnLaunch": "true"
+      }
+    },
+    "InternetGateway": {
+      "Type": "AWS::EC2::InternetGateway"
+    },
+    "GatewayAttachment": {
+      "Type": "AWS::EC2::VPCGatewayAttachment",
+      "Properties": {
+        "VpcId": { "Ref": "VPC" },
+        "InternetGatewayId": { "Ref": "InternetGateway" }
+      }
+    },
+    "RouteTable": {
+      "Type": "AWS::EC2::RouteTable",
+      "Properties": {
+        "VpcId": { "Ref": "VPC" }
+      }
+    },
+    "Route": {
+      "Type": "AWS::EC2::Route",
+      "DependsOn": "GatewayAttachment",
+      "Properties": {
+        "RouteTableId": { "Ref": "RouteTable" },
+        "DestinationCidrBlock": "0.0.0.0/0",
+        "GatewayId": { "Ref": "InternetGateway" }
+      }
+    },
+    "Subnet1RouteTableAssociation": {
+      "Type": "AWS::EC2::SubnetRouteTableAssociation",
+      "Properties": {
+        "SubnetId": { "Ref": "PublicSubnet1" },
+        "RouteTableId": { "Ref": "RouteTable" }
+      }
+    },
+    "Subnet2RouteTableAssociation": {
+      "Type": "AWS::EC2::SubnetRouteTableAssociation",
+      "Properties": {
+        "SubnetId": { "Ref": "PublicSubnet2" },
+        "RouteTableId": { "Ref": "RouteTable" }
+      }
+    },
+    "ECSSecurityGroup": {
+      "Type": "AWS::EC2::SecurityGroup",
+      "Properties": {
+        "GroupDescription": "Security Group for ECS Tasks",
+        "VpcId": { "Ref": "VPC" },
+        "SecurityGroupIngress": [
+          {
+            "IpProtocol": "tcp",
+            "FromPort": 80,
+            "ToPort": 80,
+            "SourceSecurityGroupId": { "Ref": "ELBSecurityGroup" }
+          }
+        ]
+      }
+    },
+    "ELBSecurityGroup": {
+      "Type": "AWS::EC2::SecurityGroup",
+      "Properties": {
+        "GroupDescription": "Security Group for ELB",
+        "VpcId": { "Ref": "VPC" },
+        "SecurityGroupIngress": [
+          {
+            "IpProtocol": "tcp",
+            "FromPort": 80,
+            "ToPort": 80,
+            "CidrIp": "0.0.0.0/0"
+          }
+        ]
+      }
+    },
+    "ECSTaskRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Principal": {
+                "Service": ["ecs-tasks.amazonaws.com"]
+              },
+              "Action": ["sts:AssumeRole"]
+            }
+          ]
+        },
+        "Path": "/",
+        "Policies": [
+          {
+            "PolicyName": "ecs-service",
+            "PolicyDocument": {
+              "Version": "2012-10-17",
+              "Statement": [
+                {
+                  "Effect": "Allow",
+                  "Action": [
+                    "ec2:AuthorizeSecurityGroupIngress",
+                    "ec2:Describe*",
+                    "elasticloadbalancing:DeregisterInstancesFromLoadBalancer",
+                    "elasticloadbalancing:DeregisterTargets",
+                    "elasticloadbalancing:Describe*",
+                    "elasticloadbalancing:RegisterInstancesWithLoadBalancer",
+                    "elasticloadbalancing:RegisterTargets",
+                    "ec2:CreateSecurityGroup",
+                    "ec2:DeleteSecurityGroup",
+                    "logs:CreateLogGroup",
+                    "logs:CreateLogStream",
+                    "logs:DescribeLogStreams",
+                    "logs:PutLogEvents"
+                  ],
+                  "Resource": "*"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/local-test-configuration/pusher-1/pusher.json
+++ b/local-test-configuration/pusher-1/pusher.json
@@ -36,7 +36,7 @@
   "signedApis": [
     {
       "name": "signed-api-1",
-      "url": "signed-api-elb-id-1-189541715.us-east-1.elb.amazonaws.com"
+      "url": "http://signed-api-elb-id-1-189541715.us-east-1.elb.amazonaws.com/"
     }
   ],
   "ois": [

--- a/local-test-configuration/pusher-1/pusher.json
+++ b/local-test-configuration/pusher-1/pusher.json
@@ -22,7 +22,7 @@
   "triggers": {
     "signedApiUpdates": [
       {
-        "signedApiName": "localhost",
+        "signedApiName": "signed-api-1",
         "templateIds": [
           "0xa5419706d8edb3bbafad83fe2b4e7dc851de5e4cd9529f9f27bb393016c81ae5",
           "0x8f255387c5fdb03117d82372b8fa5c7813881fd9a8202b7cc373f1a5868496b2",
@@ -35,8 +35,8 @@
   },
   "signedApis": [
     {
-      "name": "localhost",
-      "url": "http://${LOCALHOST_IP}:4001"
+      "name": "signed-api-1",
+      "url": "signed-api-elb-id-1-189541715.us-east-1.elb.amazonaws.com"
     }
   ],
   "ois": [
@@ -94,7 +94,7 @@
   ],
   "nodeSettings": {
     "nodeVersion": "0.1.0",
-    "airnodeWalletMnemonic": "${AIRNODE_WALLET_MNEMONIC}",
+    "airnodeWalletMnemonic": "${WALLET_MNEMONIC}",
     "stage": "local-example"
   }
 }

--- a/local-test-configuration/pusher-2/pusher.json
+++ b/local-test-configuration/pusher-2/pusher.json
@@ -36,7 +36,7 @@
   "signedApis": [
     {
       "name": "signed-api-2",
-      "url": "signed-api-elb-id-2-711433081.us-east-1.elb.amazonaws.com"
+      "url": "http://signed-api-elb-id-2-711433081.us-east-1.elb.amazonaws.com"
     }
   ],
   "ois": [

--- a/local-test-configuration/pusher-2/pusher.json
+++ b/local-test-configuration/pusher-2/pusher.json
@@ -22,7 +22,7 @@
   "triggers": {
     "signedApiUpdates": [
       {
-        "signedApiName": "localhost",
+        "signedApiName": "signed-api-2",
         "templateIds": [
           "0xa5419706d8edb3bbafad83fe2b4e7dc851de5e4cd9529f9f27bb393016c81ae5",
           "0x8f255387c5fdb03117d82372b8fa5c7813881fd9a8202b7cc373f1a5868496b2",
@@ -35,8 +35,8 @@
   },
   "signedApis": [
     {
-      "name": "localhost",
-      "url": "http://${LOCALHOST_IP}:4002"
+      "name": "signed-api-2",
+      "url": "signed-api-elb-id-2-711433081.us-east-1.elb.amazonaws.com"
     }
   ],
   "ois": [
@@ -94,7 +94,7 @@
   ],
   "nodeSettings": {
     "nodeVersion": "0.1.0",
-    "airnodeWalletMnemonic": "${AIRNODE_WALLET_MNEMONIC}",
+    "airnodeWalletMnemonic": "${WALLET_MNEMONIC}",
     "stage": "local-example"
   }
 }

--- a/local-test-configuration/scripts/initialize-chain.ts
+++ b/local-test-configuration/scripts/initialize-chain.ts
@@ -305,7 +305,7 @@ export const deploy = async (funderWallet: ethers.Wallet, provider: ethers.provi
     tx = await dapiDataRegistry.connect(randomPerson).registerDataFeed(encodedBeaconSetData);
     await tx.wait();
     const HUNDRED_PERCENT = 1e8;
-    const deviationThresholdInPercentage = ethers.BigNumber.from(HUNDRED_PERCENT / 100); // 1%
+    const deviationThresholdInPercentage = ethers.BigNumber.from(HUNDRED_PERCENT / 100); // 1% TODO: revert
     const deviationReference = ethers.constants.Zero; // Not used in Airseeker V1
     const heartbeatInterval = ethers.BigNumber.from(86_400); // 24 hrs
     const [dapiName, beaconSetId, sponsorWalletMnemonic] = dapiTreeValue;

--- a/local-test-configuration/scripts/initialize-chain.ts
+++ b/local-test-configuration/scripts/initialize-chain.ts
@@ -305,7 +305,7 @@ export const deploy = async (funderWallet: ethers.Wallet, provider: ethers.provi
     tx = await dapiDataRegistry.connect(randomPerson).registerDataFeed(encodedBeaconSetData);
     await tx.wait();
     const HUNDRED_PERCENT = 1e8;
-    const deviationThresholdInPercentage = ethers.BigNumber.from(HUNDRED_PERCENT / 100); // 1% TODO: revert
+    const deviationThresholdInPercentage = ethers.BigNumber.from(HUNDRED_PERCENT / 100); // 1% // NOTE: Increased to 1% to reduce the number of sponsor wallet transcations.
     const deviationReference = ethers.constants.Zero; // Not used in Airseeker V1
     const heartbeatInterval = ethers.BigNumber.from(86_400); // 24 hrs
     const [dapiName, beaconSetId, sponsorWalletMnemonic] = dapiTreeValue;

--- a/local-test-configuration/signed-api-1/signed-api.json
+++ b/local-test-configuration/signed-api-1/signed-api.json
@@ -7,6 +7,7 @@
   ],
   "allowedAirnodes": ["0xaC0653E412acAE526Da3a33af0135205A34E21AF"],
   "maxBatchSize": 10,
+  "port": 80,
   "cache": {
     "maxAgeSeconds": 300
   }

--- a/local-test-configuration/signed-api-2/signed-api.json
+++ b/local-test-configuration/signed-api-2/signed-api.json
@@ -7,6 +7,7 @@
   ],
   "allowedAirnodes": ["0x2Bf0dddA8Daa1C3C0Fae9e85866807A1C2D601B7"],
   "maxBatchSize": 10,
+  "port": 80,
   "cache": {
     "maxAgeSeconds": 300
   }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "*.js"
   ],
   "scripts": {
-    "build": "pnpm run contracts:compile && tsc --project tsconfig.build.json",
+    "build": "tsc --project tsconfig.build.json",
     "clean": "rm -rf coverage dist artifacts cache src/typechain-types",
     "contracts:compile:force": "hardhat compile --force",
     "contracts:compile": "hardhat compile",


### PR DESCRIPTION
Closes https://github.com/api3dao/airseeker-v2/issues/97

## Intention

I want to open this PR to show the CF templates and configurations used for visibility. **It should not be merged**.

## Rationale

I've used the CloudFormation templates for Pushers and Signed APIs and and modified the e2e configurations so they can be used for AWS deployments. I chose to commit for reference, but they are quite easy to re-create from the official templates.

I had troubles building docker with linux platform on my macOS because of solidity (used to build TypeChain fixtures in the docker image) so I did a hack and reused the files that I have built locally.

I was running into user limits for VPC count and internet gateway count (5 is the limit) but I overcome it by deploying the services across multiple regions.

Airseeker image is pusher on my personal Docker Hub account [here](https://hub.docker.com/r/siegrift/api3-airseeker-v2/tags).

These are the contracts:
- [Api3ServerV1](https://mumbai.polygonscan.com/address/0x9A0F9f6dE89BE3D155483A469a5feB2eE875fB5F)
- [DapiDataRegistry](https://mumbai.polygonscan.com/address/0xb062aE0e1bBf6E2D1a9eA6e5750357979eA8A3f6)