### PR TITLE
Use historical saved gas price when RPC gas price fails

### DIFF
--- a/src/update-feeds-loops/submit-transactions.ts
+++ b/src/update-feeds-loops/submit-transactions.ts
@@ -85,22 +85,8 @@ export const submitTransaction = async (
         const sponsorWallet = getDerivedSponsorWallet(sponsorWalletMnemonic, dapiName);
 
         logger.debug('Getting gas price');
-        const goGasPrice = await go(
-          async () =>
-            getRecommendedGasPrice(
-              chainId,
-              providerName,
-              provider,
-              chains[chainId]!.gasSettings,
-              sponsorWallet.address
-            ),
-          { totalTimeoutMs: dataFeedUpdateIntervalMs }
-        );
-        if (!goGasPrice.success) {
-          logger.error(`Failed to get gas price`, goGasPrice.error);
-          return null;
-        }
-        const gasPrice = goGasPrice.data;
+        const gasPrice = await getRecommendedGasPrice(chainId, providerName, provider, sponsorWallet.address);
+        if (!gasPrice) return null;
 
         // We want to set the timestamp of the first update transaction. We can determine if the transaction is the
         // original one and that it isn't a retry of a pending transaction (if there is no timestamp for the
@@ -110,7 +96,7 @@ export const submitTransaction = async (
           setSponsorLastUpdateTimestamp(chainId, providerName, sponsorWallet.address);
         }
 
-        logger.debug('Updating dAPI', { gasPrice: goGasPrice.data.toString(), gasLimit: gasLimit.toString() });
+        logger.debug('Updating dAPI', { gasPrice: gasPrice.toString(), gasLimit: gasLimit.toString() });
         const goMulticall = await go(async () => {
           return (
             api3ServerV1


### PR DESCRIPTION
Closes https://github.com/api3dao/airseeker-v2/issues/147

## Rationale

I changed the `getRecommendedGasPrice` to reuse the latest saved gas price (if fresh) and made the function non-throwing and instead return `null` if there is no gas price to use.