### PR TITLE
Multicall chain info

### DIFF
--- a/local-test-configuration/airnode-feed-1/airnode-feed.json
+++ b/local-test-configuration/airnode-feed-1/airnode-feed.json
@@ -36,12 +36,13 @@
   "signedApis": [
     {
       "name": "localhost",
-      "url": "http://${LOCALHOST_IP}:4001"
+      "url": "http://${LOCALHOST_IP}:4001",
+      "authToken": null
     }
   ],
   "ois": [
     {
-      "oisFormat": "2.2.0",
+      "oisFormat": "2.3.1",
       "title": "Nodary",
       "version": "0.2.0",
       "apiSpecifications": {
@@ -93,7 +94,7 @@
     }
   ],
   "nodeSettings": {
-    "nodeVersion": "0.1.0",
+    "nodeVersion": "0.2.0",
     "airnodeWalletMnemonic": "${AIRNODE_WALLET_MNEMONIC}",
     "stage": "local-example"
   }

--- a/local-test-configuration/airnode-feed-2/airnode-feed.json
+++ b/local-test-configuration/airnode-feed-2/airnode-feed.json
@@ -36,12 +36,13 @@
   "signedApis": [
     {
       "name": "localhost",
-      "url": "http://${LOCALHOST_IP}:4002"
+      "url": "http://${LOCALHOST_IP}:4002",
+      "authToken": null
     }
   ],
   "ois": [
     {
-      "oisFormat": "2.2.0",
+      "oisFormat": "2.3.1",
       "title": "Nodary",
       "version": "0.2.0",
       "apiSpecifications": {
@@ -93,7 +94,7 @@
     }
   ],
   "nodeSettings": {
-    "nodeVersion": "0.1.0",
+    "nodeVersion": "0.2.0",
     "airnodeWalletMnemonic": "${AIRNODE_WALLET_MNEMONIC}",
     "stage": "local-example"
   }

--- a/local-test-configuration/monitoring/index.html
+++ b/local-test-configuration/monitoring/index.html
@@ -793,8 +793,12 @@
     }
 
     const deriveSponsorWallet = (sponsorWalletMnemonic, dapiNameOrDataFeedId) => {
-      // Take first 20 bytes of dapiName or data feed ID as sponsor address together with the "0x" prefix.
-      const sponsorAddress = ethers.utils.getAddress(dapiNameOrDataFeedId.slice(0, 42));
+      // Hash the dAPI name or data feed ID because we need to take the first 20 bytes of it which could result in
+      // collisions for dAPIs with the same prefix.
+      const hashedDapiNameOrDataFeedId = ethers.utils.keccak256(dapiNameOrDataFeedId);
+
+      // Take first 20 bytes of the hashed dapiName or data feed ID as sponsor address together with the "0x" prefix.
+      const sponsorAddress = ethers.utils.getAddress(hashedDapiNameOrDataFeedId.slice(0, 42));
       const sponsorWallet = ethers.Wallet.fromMnemonic(
         sponsorWalletMnemonic,
         `m/44'/60'/0'/${deriveWalletPathFromSponsorAddress(sponsorAddress)}`
@@ -811,11 +815,17 @@
       document.getElementById('activeDataFeedCount').innerHTML = activeDataFeedCount;
       let newActiveDataFeedsHtml = '';
       for (let i = 0; i < activeDataFeedCount; i++) {
-        const { dataFeedId, dapiName, updateParameters, dataFeedValue, dataFeedDetails, signedApiUrls } =
-          await airseekerRegistry.activeDataFeed(i);
+        const {
+          dataFeedId,
+          dapiName,
+          updateParameters,
+          dataFeedValue,
+          dataFeedTimestamp,
+          dataFeedDetails,
+          signedApiUrls,
+        } = await airseekerRegistry.activeDataFeed(i);
         const { deviationReference, deviationThresholdInPercentage, heartbeatInterval } =
           decodeUpdateParameters(updateParameters);
-        const { value, timestamp } = dataFeedValue;
         const dataFeed = {
           dataFeedId,
           dapiName,
@@ -824,7 +834,8 @@
             deviationThresholdInPercentage: deviationThresholdInPercentage.toString(),
             heartbeatInterval: heartbeatInterval,
           },
-          dataFeedValue: { value: value.toString(), timestamp },
+          dataFeedValue: dataFeedValue.toString(),
+          dataFeedTimestamp: dataFeedTimestamp.toString(),
           decodedDataFeed: decodeDataFeedDetails(dataFeedDetails),
           signedApiUrls,
         };
@@ -832,11 +843,9 @@
 
         let signedDatas = [];
         for (let i = 0; i < signedApiUrls.length; i++) {
-          const url = signedApiUrls[i];
+          const url = signedApiUrls[i].replace('host.docker.internal', 'localhost');
           const airnode = dataFeed.decodedDataFeed.beacons[i].airnodeAddress;
-          const signedApiResponse = await fetch(`${url.replace('host.docker.internal', 'localhost')}/${airnode}`).then(
-            (res) => res.json()
-          );
+          const signedApiResponse = await fetch(`${url}/${airnode}`).then((res) => res.json());
           const signedData = signedApiResponse.data[dataFeed.decodedDataFeed.beacons[i].beaconId];
           signedDatas.push({ ...signedData, value: decodeBeaconValue(signedData.encodedValue).toString() });
         }
@@ -849,7 +858,7 @@
           signedDatas.map((signedData) => ethers.BigNumber.from(signedData.timestamp))
         ).toNumber();
 
-        const deviationPercentage = calculateUpdateInPercentage(value, newBeaconSetValue).toNumber() / 1e6;
+        const deviationPercentage = calculateUpdateInPercentage(dataFeedValue, newBeaconSetValue).toNumber() / 1e6;
         const deviationThresholdPercentage = deviationThresholdInPercentage.toNumber() / 1e6;
         const sponsorWallet = deriveSponsorWallet(airseekerMnemonic, dapiName ?? dataFeed.decodedDataFeed.dataFeedId);
         const dataFeedInfo = {

--- a/local-test-configuration/signed-api-1/signed-api.json
+++ b/local-test-configuration/signed-api-1/signed-api.json
@@ -2,12 +2,11 @@
   "endpoints": [
     {
       "urlPath": "/default",
-      "delaySeconds": 0
+      "delaySeconds": 0,
+      "authTokens": null
     }
   ],
-  "allowedAirnodes": ["0xaC0653E412acAE526Da3a33af0135205A34E21AF"],
-  "maxBatchSize": 10,
-  "cache": {
-    "maxAgeSeconds": 300
-  }
+  "allowedAirnodes": [{ "address": "0xaC0653E412acAE526Da3a33af0135205A34E21AF", "authTokens": null }],
+  "stage": "signed-api-1",
+  "version": "0.2.0"
 }

--- a/local-test-configuration/signed-api-2/signed-api.json
+++ b/local-test-configuration/signed-api-2/signed-api.json
@@ -2,12 +2,11 @@
   "endpoints": [
     {
       "urlPath": "/default",
-      "delaySeconds": 60
+      "delaySeconds": 0,
+      "authTokens": null
     }
   ],
-  "allowedAirnodes": ["0x2Bf0dddA8Daa1C3C0Fae9e85866807A1C2D601B7"],
-  "maxBatchSize": 10,
-  "cache": {
-    "maxAgeSeconds": 300
-  }
+  "allowedAirnodes": [{ "address": "0x2Bf0dddA8Daa1C3C0Fae9e85866807A1C2D601B7", "authTokens": null }],
+  "stage": "signed-api-2",
+  "version": "0.2.0"
 }

--- a/src/update-feeds-loops/contracts.ts
+++ b/src/update-feeds-loops/contracts.ts
@@ -21,15 +21,16 @@ export const verifyMulticallResponse = (
   return returndata;
 };
 
-export const decodeActiveDataFeedCountResponse = (
-  airseekerRegistry: AirseekerRegistry,
-  activeDataFeedCountReturndata: string
-) => {
-  const activeDataFeedCount = airseekerRegistry.interface.decodeFunctionResult(
-    'activeDataFeedCount',
-    activeDataFeedCountReturndata
-  )[0] as Awaited<ReturnType<AirseekerRegistry['activeDataFeedCount']>>;
-  return activeDataFeedCount.toNumber();
+export const decodeActiveDataFeedCountResponse = (activeDataFeedCountReturndata: string) => {
+  return ethers.BigNumber.from(activeDataFeedCountReturndata).toNumber();
+};
+
+export const decodeGetBlockNumberResponse = (getBlockNumberReturndata: string) => {
+  return ethers.BigNumber.from(getBlockNumberReturndata).toNumber();
+};
+
+export const decodeGetChainIdResponse = (getChainIdReturndata: string) => {
+  return ethers.BigNumber.from(getChainIdReturndata).toNumber();
 };
 
 export const decodeDataFeedDetails = (dataFeed: string): DecodedDataFeed | null => {

--- a/src/update-feeds-loops/get-updatable-feeds.test.ts
+++ b/src/update-feeds-loops/get-updatable-feeds.test.ts
@@ -41,6 +41,7 @@ describe(multicallBeaconValues.name, () => {
     const tryMulticallMock = jest.fn().mockReturnValue({
       successes: [true, true, true],
       returndata: [
+        ethers.utils.defaultAbiCoder.encode(['uint256'], [31_337]),
         ethers.utils.defaultAbiCoder.encode(['int224', 'uint32'], [100, 105]),
         ethers.utils.defaultAbiCoder.encode(['int224', 'uint32'], [101, 106]),
         ethers.utils.defaultAbiCoder.encode(['int224', 'uint32'], [102, 107]),
@@ -48,9 +49,10 @@ describe(multicallBeaconValues.name, () => {
     });
 
     const encodeFunctionDataMock = jest.fn();
-    encodeFunctionDataMock.mockReturnValueOnce('0xfirst');
-    encodeFunctionDataMock.mockReturnValueOnce('0xsecond');
-    encodeFunctionDataMock.mockReturnValueOnce('0xthird');
+    encodeFunctionDataMock.mockReturnValueOnce('0xChain');
+    encodeFunctionDataMock.mockReturnValueOnce('0xFirst');
+    encodeFunctionDataMock.mockReturnValueOnce('0xSecond');
+    encodeFunctionDataMock.mockReturnValueOnce('0xThird');
 
     const mockContract = {
       connect: jest.fn().mockReturnValue({
@@ -79,7 +81,7 @@ describe(multicallBeaconValues.name, () => {
         value: ethers.BigNumber.from(102),
       },
     });
-    expect(tryMulticallMock).toHaveBeenCalledWith(['0xfirst', '0xsecond', '0xthird']);
+    expect(tryMulticallMock).toHaveBeenCalledWith(['0xChain', '0xFirst', '0xSecond', '0xThird']);
   });
 });
 

--- a/src/update-feeds-loops/get-updatable-feeds.test.ts
+++ b/src/update-feeds-loops/get-updatable-feeds.test.ts
@@ -63,7 +63,12 @@ describe(multicallBeaconValues.name, () => {
 
     jest.spyOn(contractsModule, 'getApi3ServerV1').mockReturnValue(mockContract as any);
 
-    const callAndParseMulticallPromise = await multicallBeaconValues(feedIds as unknown as string[], provider, '31337');
+    const callAndParseMulticallPromise = await multicallBeaconValues(
+      feedIds as unknown as string[],
+      provider,
+      '31337',
+      1
+    );
 
     expect(callAndParseMulticallPromise).toStrictEqual({
       '0xf5c140bcb4814dfec311d38f6293e86c02d32ba1b7da027fe5b5202cae35dbc6': {

--- a/src/update-feeds-loops/get-updatable-feeds.test.ts
+++ b/src/update-feeds-loops/get-updatable-feeds.test.ts
@@ -63,12 +63,7 @@ describe(multicallBeaconValues.name, () => {
 
     jest.spyOn(contractsModule, 'getApi3ServerV1').mockReturnValue(mockContract as any);
 
-    const callAndParseMulticallPromise = await multicallBeaconValues(
-      feedIds as unknown as string[],
-      provider,
-      '31337',
-      1
-    );
+    const callAndParseMulticallPromise = await multicallBeaconValues(feedIds as unknown as string[], provider, '31337');
 
     expect(callAndParseMulticallPromise).toStrictEqual({
       '0xf5c140bcb4814dfec311d38f6293e86c02d32ba1b7da027fe5b5202cae35dbc6': {

--- a/src/update-feeds-loops/get-updatable-feeds.ts
+++ b/src/update-feeds-loops/get-updatable-feeds.ts
@@ -34,7 +34,8 @@ export const getUpdatableFeeds = async (
   const uniqueBeaconIds = [
     ...new Set(batch.flatMap((item) => item.decodedDataFeed.beacons.flatMap((beacon) => beacon.beaconId))),
   ];
-  const goOnChainFeedValues = await go(async () => multicallBeaconValues(uniqueBeaconIds, provider, chainId));
+  // TODO:
+  const goOnChainFeedValues = await go(async () => multicallBeaconValues(uniqueBeaconIds, provider, chainId, 0));
   if (!goOnChainFeedValues.success) {
     logger.error(
       `Multicalling on-chain data feed values has failed. Skipping update for all data feeds in a batch`,

--- a/src/update-feeds-loops/get-updatable-feeds.ts
+++ b/src/update-feeds-loops/get-updatable-feeds.ts
@@ -47,6 +47,7 @@ export const getUpdatableFeeds = async (
     return [];
   }
   const onChainFeedValues = goOnChainFeedValues.data;
+  if (!onChainFeedValues) return [];
 
   return (
     batch
@@ -112,7 +113,7 @@ export const multicallBeaconValues = async (
   batch: BeaconId[],
   provider: ethers.providers.StaticJsonRpcProvider,
   chainId: ChainId
-): Promise<Record<BeaconId, BeaconValue>> => {
+): Promise<Record<BeaconId, BeaconValue> | null> => {
   const { config } = getState();
   const chain = config.chains[chainId]!;
   const { contracts } = chain;
@@ -131,7 +132,8 @@ export const multicallBeaconValues = async (
 
   const contractChainId = decodeGetChainIdResponse(chainIdReturndata!).toString();
   if (contractChainId !== chainId) {
-    throw new Error(`Chain ID mismatch. Expected ${chainId}, got ${contractChainId}`);
+    logger.warn(`Chain ID mismatch.`, { chainId, contractChainId });
+    return null;
   }
 
   const onChainValues: Record<BeaconId, BeaconValue> = {};

--- a/src/update-feeds-loops/submit-transactions.test.ts
+++ b/src/update-feeds-loops/submit-transactions.test.ts
@@ -309,7 +309,8 @@ describe(submitTransactionsModule.submitTransactions.name, () => {
         allowPartial<UpdatableDataFeed>({
           dataFeedInfo: { dapiName: utilsModule.encodeDapiName('BTC/USD') },
         }),
-      ]
+      ],
+      123_456
     );
 
     expect(submitTransactionsModule.submitTransaction).toHaveBeenCalledTimes(2);

--- a/src/update-feeds-loops/submit-transactions.test.ts
+++ b/src/update-feeds-loops/submit-transactions.test.ts
@@ -356,7 +356,8 @@ describe(submitTransactionsModule.submitTransaction.name, () => {
             dataFeedId: '0xBeaconSetId',
           },
         },
-      })
+      }),
+      1
     );
 
     // Verify that the data feed was updated successfully.

--- a/src/update-feeds-loops/submit-transactions.test.ts
+++ b/src/update-feeds-loops/submit-transactions.test.ts
@@ -344,11 +344,14 @@ describe(submitTransactionsModule.submitTransaction.name, () => {
       })
     );
     jest.spyOn(stateModule, 'updateState').mockImplementation();
+    const provider = {
+      getTransactionCount: jest.fn().mockResolvedValue(0),
+    } as unknown as ethers.providers.StaticJsonRpcProvider;
 
     await submitTransactionsModule.submitTransaction(
       '31337',
       'evm-local',
-      new ethers.providers.StaticJsonRpcProvider(),
+      provider,
       api3ServerV1 as unknown as Api3ServerV1,
       allowPartial<UpdatableDataFeed>({
         dataFeedInfo: {
@@ -362,8 +365,14 @@ describe(submitTransactionsModule.submitTransaction.name, () => {
     );
 
     // Verify that the data feed was updated successfully.
-    expect(logger.info).toHaveBeenCalledTimes(1);
-    expect(logger.info).toHaveBeenCalledWith('Successfully updated data feed.');
+    expect(logger.info).toHaveBeenCalledTimes(2);
+    expect(logger.info).toHaveBeenNthCalledWith(1, 'Updating data feed.', {
+      gasLimit: '500000',
+      gasPrice: '100000000',
+      nonce: 0,
+      sponsorAddress: '0xA772F7b103BBecA3Bb6C74Be41fCc2c192C8146c',
+    });
+    expect(logger.info).toHaveBeenNthCalledWith(2, 'Successfully updated data feed.');
 
     // Verify the flow of the update process via the debug logs. Note, that some debug log calls are not here because
     // many functions are mocked.
@@ -374,11 +383,8 @@ describe(submitTransactionsModule.submitTransaction.name, () => {
     expect(logger.debug).toHaveBeenNthCalledWith(4, 'Derived new sponsor wallet.', {
       sponsorWalletAddress: '0xA772F7b103BBecA3Bb6C74Be41fCc2c192C8146c',
     });
-    expect(logger.debug).toHaveBeenNthCalledWith(5, 'Getting gas price.');
-    expect(logger.debug).toHaveBeenNthCalledWith(6, 'Setting timestamp of the original update transaction.');
-    expect(logger.debug).toHaveBeenNthCalledWith(7, 'Updating data feed.', {
-      gasLimit: '500000',
-      gasPrice: '100000000',
-    });
+    expect(logger.debug).toHaveBeenNthCalledWith(5, 'Getting nonce.');
+    expect(logger.debug).toHaveBeenNthCalledWith(6, 'Getting gas price.');
+    expect(logger.debug).toHaveBeenNthCalledWith(7, 'Setting timestamp of the original update transaction.');
   });
 });

--- a/src/update-feeds-loops/submit-transactions.test.ts
+++ b/src/update-feeds-loops/submit-transactions.test.ts
@@ -361,7 +361,7 @@ describe(submitTransactionsModule.submitTransaction.name, () => {
           },
         },
       }),
-      1
+      123_456
     );
 
     // Verify that the data feed was updated successfully.

--- a/src/update-feeds-loops/submit-transactions.ts
+++ b/src/update-feeds-loops/submit-transactions.ts
@@ -141,7 +141,8 @@ export const submitTransactions = async (
 ) =>
   Promise.all(
     updatableDataFeeds.map(async (dataFeed) =>
-      submitTransaction(chainId, providerName, provider, api3ServerV1, dataFeed)
+      // TODO:
+      submitTransaction(chainId, providerName, provider, api3ServerV1, dataFeed, 0)
     )
   );
 

--- a/src/update-feeds-loops/submit-transactions.ts
+++ b/src/update-feeds-loops/submit-transactions.ts
@@ -123,7 +123,7 @@ export const submitTransaction = async (
             logger.info(`Failed to submit replacement transaction because it was underpriced.`);
             return null;
           }
-          logger.error(`Failed to update a data feed.`, goMulticall.error);
+          logger.info(`Failed to update a data feed.`, goMulticall.error);
           return null;
         }
 

--- a/src/update-feeds-loops/submit-transactions.ts
+++ b/src/update-feeds-loops/submit-transactions.ts
@@ -47,7 +47,8 @@ export const submitTransaction = async (
   providerName: ProviderName,
   provider: ethers.providers.StaticJsonRpcProvider,
   api3ServerV1: Api3ServerV1,
-  updatableDataFeed: UpdatableDataFeed
+  updatableDataFeed: UpdatableDataFeed,
+  blockNumber: number
 ) => {
   const state = getState();
   const {
@@ -63,7 +64,7 @@ export const submitTransaction = async (
   const { dataFeedUpdateInterval, fallbackGasLimit } = chains[chainId]!;
   const dataFeedUpdateIntervalMs = dataFeedUpdateInterval * 1000;
 
-  return logger.runWithContext({ dapiName: decodedDapiName, dataFeedId }, async () => {
+  return logger.runWithContext({ dapiName: decodedDapiName, dataFeedId, blockNumber }, async () => {
     // NOTE: We use go mainly to set a timeout for the whole update process. We expect the function not to throw and
     // handle errors internally.
     const goUpdate = await go(
@@ -84,6 +85,9 @@ export const submitTransaction = async (
         logger.debug('Getting derived sponsor wallet.');
         const sponsorWallet = getDerivedSponsorWallet(sponsorWalletMnemonic, dapiName ?? dataFeedId);
 
+        logger.debug('Getting nonce.');
+        const nonce = await provider.getTransactionCount(sponsorWallet.address, blockNumber);
+
         logger.debug('Getting gas price.');
         const gasPrice = await getRecommendedGasPrice(chainId, providerName, provider, sponsorWallet.address);
         if (!gasPrice) return null;
@@ -96,14 +100,19 @@ export const submitTransaction = async (
           setSponsorLastUpdateTimestamp(chainId, providerName, sponsorWallet.address);
         }
 
-        logger.debug('Updating data feed.', { gasPrice: gasPrice.toString(), gasLimit: gasLimit.toString() });
+        logger.info('Updating data feed.', {
+          sponsorAddress: sponsorWallet.address,
+          gasPrice: gasPrice.toString(),
+          gasLimit: gasLimit.toString(),
+          nonce,
+        });
         const goMulticall = await go(async () => {
           return (
             api3ServerV1
               // When we add the sponsor wallet (signer) without connecting it to the provider, the provider of the
               // contract will be set to "null". We need to connect the sponsor wallet to the provider of the contract.
               .connect(sponsorWallet.connect(api3ServerV1.provider))
-              .tryMulticall(dataFeedUpdateCalldatas, { gasPrice, gasLimit })
+              .tryMulticall(dataFeedUpdateCalldatas, { gasPrice, gasLimit, nonce })
           );
         });
         if (!goMulticall.success) {
@@ -137,12 +146,12 @@ export const submitTransactions = async (
   providerName: ProviderName,
   provider: ethers.providers.StaticJsonRpcProvider,
   api3ServerV1: Api3ServerV1,
-  updatableDataFeeds: UpdatableDataFeed[]
+  updatableDataFeeds: UpdatableDataFeed[],
+  blockNumber: number
 ) =>
   Promise.all(
     updatableDataFeeds.map(async (dataFeed) =>
-      // TODO:
-      submitTransaction(chainId, providerName, provider, api3ServerV1, dataFeed, 0)
+      submitTransaction(chainId, providerName, provider, api3ServerV1, dataFeed, blockNumber)
     )
   );
 

--- a/src/update-feeds-loops/update-feeds-loops.test.ts
+++ b/src/update-feeds-loops/update-feeds-loops.test.ts
@@ -193,12 +193,20 @@ describe(updateFeedsLoopsModule.runUpdateFeeds.name, () => {
       .spyOn(contractsModule, 'getAirseekerRegistry')
       .mockReturnValue(airseekerRegistry as unknown as AirseekerRegistry);
     airseekerRegistry.interface.decodeFunctionResult.mockImplementation((_fn, value) => value);
+    const blockNumber = ethers.BigNumber.from(123);
+    const chainId = ethers.BigNumber.from(31_337);
     airseekerRegistry.callStatic.tryMulticall.mockResolvedValueOnce({
-      successes: [true, true],
-      returndata: [[ethers.BigNumber.from(3)], firstDataFeed],
+      successes: [true, true, true, true],
+      returndata: [ethers.BigNumber.from(3), ethers.BigNumber.from(123), chainId, firstDataFeed],
     });
-    airseekerRegistry.callStatic.tryMulticall.mockResolvedValueOnce({ successes: [false], returndata: [] });
-    airseekerRegistry.callStatic.tryMulticall.mockResolvedValueOnce({ successes: [true], returndata: [thirdDataFeed] });
+    airseekerRegistry.callStatic.tryMulticall.mockResolvedValueOnce({
+      successes: [true, true, false],
+      returndata: [blockNumber, chainId, '0x'],
+    });
+    airseekerRegistry.callStatic.tryMulticall.mockResolvedValueOnce({
+      successes: [true, true, true],
+      returndata: [blockNumber, chainId, thirdDataFeed],
+    });
     const sleepCalls = [] as number[];
     const originalSleep = utilsModule.sleep;
     jest.spyOn(utilsModule, 'sleep').mockImplementation(async (ms) => {
@@ -299,9 +307,11 @@ describe(updateFeedsLoopsModule.runUpdateFeeds.name, () => {
       .spyOn(contractsModule, 'getAirseekerRegistry')
       .mockReturnValue(airseekerRegistry as unknown as AirseekerRegistry);
     airseekerRegistry.interface.decodeFunctionResult.mockImplementation((_fn, value) => value);
+    const blockNumber = ethers.BigNumber.from(123);
+    const chainId = ethers.BigNumber.from(31_337);
     airseekerRegistry.callStatic.tryMulticall.mockResolvedValueOnce({
-      successes: [true, true],
-      returndata: [[ethers.BigNumber.from(1)], dataFeed],
+      successes: [true, true, true, true],
+      returndata: [ethers.BigNumber.from(1), blockNumber, chainId, dataFeed],
     });
     const testConfig = generateTestConfig();
     jest.spyOn(stateModule, 'getState').mockReturnValue(

--- a/src/update-feeds-loops/update-feeds-loops.test.ts
+++ b/src/update-feeds-loops/update-feeds-loops.test.ts
@@ -197,7 +197,7 @@ describe(updateFeedsLoopsModule.runUpdateFeeds.name, () => {
     const chainId = ethers.BigNumber.from(31_337);
     airseekerRegistry.callStatic.tryMulticall.mockResolvedValueOnce({
       successes: [true, true, true, true],
-      returndata: [ethers.BigNumber.from(3), ethers.BigNumber.from(123), chainId, firstDataFeed],
+      returndata: [ethers.BigNumber.from(3), blockNumber, chainId, firstDataFeed],
     });
     airseekerRegistry.callStatic.tryMulticall.mockResolvedValueOnce({
       successes: [true, true, false],

--- a/src/update-feeds-loops/update-feeds-loops.ts
+++ b/src/update-feeds-loops/update-feeds-loops.ts
@@ -133,7 +133,7 @@ export const readActiveDataFeedBatch = async (
   return {
     batch,
     blockNumber,
-    ...(activeDataFeedCount ? { activeDataFeedCount } : {}),
+    activeDataFeedCount,
   };
 };
 

--- a/src/update-feeds-loops/update-feeds-loops.ts
+++ b/src/update-feeds-loops/update-feeds-loops.ts
@@ -105,17 +105,18 @@ export const readActiveDataFeedBatch = async (
   }
   const [getBlockNumberReturndata, getChainIdReturndata, ...activeDataFeedReturndatas] = returndatas;
 
-  // Check that the chain ID is correct and throw an error if it's not because providers may switch chain ID. In case
-  // the chain ID is wrong, we want to skip all data feeds in the batch (or all of them in case this is the first
-  // batch). Another possibility is a wrong chain ID in the configuration (misconfiguration).
+  // Check that the chain ID is correct and log a warning if it's not because it's possible that providers switch chain
+  // ID at runtime by mistake. In case the chain ID is wrong, we want to skip all data feeds in the batch (or all of
+  // them in case this is the first batch). Another possibility of a wrong chain ID is misconfiguration in airseeker
+  // file.
   const contractChainId = decodeGetChainIdResponse(getChainIdReturndata!).toString();
   if (contractChainId !== chainId) {
     logger.warn(`Chain ID mismatch.`, { chainId, contractChainId });
     return null;
   }
 
-  // In the first batch we may have asked for a non-existent data feed (index out of bounds). We need to slice them off
-  // based on the active data feed count.
+  // In the first batch we may have asked for a non-existent data feed. We need to slice them off based on the active
+  // data feed count.
   let activeDataFeedCount: number | undefined;
   let batchReturndata = activeDataFeedReturndatas;
   if (fromIndex === 0) {

--- a/test/e2e/update-feeds.feature.ts
+++ b/test/e2e/update-feeds.feature.ts
@@ -111,6 +111,6 @@ it('updates blockchain data', async () => {
   );
   expect(logger.debug).toHaveBeenNthCalledWith(10, 'Setting timestamp of the original update transaction.');
   expect(logger.info).toHaveBeenCalledTimes(2);
-  expect(logger.info).toHaveBeenNthCalledWith(2, 'Updating data feed.', expect.anything());
-  expect(logger.info).toHaveBeenNthCalledWith(1, 'Successfully updated data feed.');
+  expect(logger.info).toHaveBeenNthCalledWith(1, 'Updating data feed.', expect.anything());
+  expect(logger.info).toHaveBeenNthCalledWith(2, 'Successfully updated data feed.');
 });

--- a/test/e2e/update-feeds.feature.ts
+++ b/test/e2e/update-feeds.feature.ts
@@ -70,6 +70,8 @@ it('updates blockchain data', async () => {
     (currentBlockTimestamp + 2).toString()
   );
   jest.spyOn(logger, 'debug');
+  jest.spyOn(logger, 'info');
+  const blockNumber = await provider.getBlockNumber();
 
   await submitTransactions(
     chainId,
@@ -91,7 +93,7 @@ it('updates blockchain data', async () => {
         ],
       },
     ],
-    123_456
+    blockNumber
   );
 
   expect(logger.debug).toHaveBeenCalledTimes(10);
@@ -99,13 +101,16 @@ it('updates blockchain data', async () => {
   expect(logger.debug).toHaveBeenNthCalledWith(2, 'Estimating gas limit.');
   expect(logger.debug).toHaveBeenNthCalledWith(3, 'Getting derived sponsor wallet.');
   expect(logger.debug).toHaveBeenNthCalledWith(4, 'Derived new sponsor wallet.', expect.anything());
-  expect(logger.debug).toHaveBeenNthCalledWith(5, 'Getting gas price.');
-  expect(logger.debug).toHaveBeenNthCalledWith(6, 'Fetching gas price and saving it to the state.');
-  expect(logger.debug).toHaveBeenNthCalledWith(7, 'Purging old gas prices.');
+  expect(logger.debug).toHaveBeenNthCalledWith(5, 'Getting nonce.');
+  expect(logger.debug).toHaveBeenNthCalledWith(6, 'Getting gas price.');
+  expect(logger.debug).toHaveBeenNthCalledWith(7, 'Fetching gas price and saving it to the state.');
+  expect(logger.debug).toHaveBeenNthCalledWith(8, 'Purging old gas prices.');
   expect(logger.debug).toHaveBeenNthCalledWith(
-    8,
+    9,
     'No historical gas prices to compute the percentile. Using the provider recommended gas price.'
   );
-  expect(logger.debug).toHaveBeenNthCalledWith(9, 'Setting timestamp of the original update transaction.');
-  expect(logger.debug).toHaveBeenNthCalledWith(10, 'Updating data feed.', expect.anything());
+  expect(logger.debug).toHaveBeenNthCalledWith(10, 'Setting timestamp of the original update transaction.');
+  expect(logger.info).toHaveBeenCalledTimes(2);
+  expect(logger.info).toHaveBeenNthCalledWith(2, 'Updating data feed.', expect.anything());
+  expect(logger.info).toHaveBeenNthCalledWith(1, 'Successfully updated data feed.');
 });

--- a/test/e2e/update-feeds.feature.ts
+++ b/test/e2e/update-feeds.feature.ts
@@ -71,21 +71,28 @@ it('updates blockchain data', async () => {
   );
   jest.spyOn(logger, 'debug');
 
-  await submitTransactions(chainId, providerName, provider, api3ServerV1, [
-    {
-      dataFeedInfo: activeBtcDataFeed,
-      updatableBeacons: [
-        {
-          beaconId: binanceBtcBeacon.beaconId,
-          signedData: binanceBtcSignedData,
-        },
-        {
-          beaconId: krakenBtcBeacon.beaconId,
-          signedData: krakenBtcSignedData,
-        },
-      ],
-    },
-  ]);
+  await submitTransactions(
+    chainId,
+    providerName,
+    provider,
+    api3ServerV1,
+    [
+      {
+        dataFeedInfo: activeBtcDataFeed,
+        updatableBeacons: [
+          {
+            beaconId: binanceBtcBeacon.beaconId,
+            signedData: binanceBtcSignedData,
+          },
+          {
+            beaconId: krakenBtcBeacon.beaconId,
+            signedData: krakenBtcSignedData,
+          },
+        ],
+      },
+    ],
+    123_456
+  );
 
   expect(logger.debug).toHaveBeenCalledTimes(10);
   expect(logger.debug).toHaveBeenNthCalledWith(1, 'Creating calldatas.');


### PR DESCRIPTION
Closes https://github.com/api3dao/airseeker-v2/issues/154

## Rationale

See the issue description, comments and related Slack discussions for full context. 

We fetch on-chain data in two places, 1) when fetching a batch of active data feeds and 2) when multi-calling beacon values for the batch. Both of these verify that chain ID matches the configuration and log a warning otherwise. During 1) we remember the block ID and use it to fetch the nonce (at that block) when making the update transaction. In 2) we fetch the values at `latest` the block number. See [this discussion](https://api3workspace.slack.com/archives/C05TQPT7PNJ/p1704718141612169?thread_ts=1704709566.544549&cid=C05TQPT7PNJ).

When making an update transaction we log the sponsor wallet address and a nonce of the update transaction.

I've also updated the `local-test-configuration` which was broken after https://github.com/api3dao/airseeker-v2/pull/165. 