### PR TITLE
Upgrade contracts3 update

### DIFF
--- a/config/airseeker.example.json
+++ b/config/airseeker.example.json
@@ -4,7 +4,7 @@
     "31337": {
       "contracts": {
         "Api3ServerV1": "0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512",
-        "AirseekerRegistry": "0xDD78254f864F97f65e2d86541BdaEf88A504D2B2"
+        "AirseekerRegistry": "0x9fe46736679d2d9a65f0992f2272de9f3c7fa6e0"
       },
       "providers": {
         "hardhat": {

--- a/local-test-configuration/monitoring/index.html
+++ b/local-test-configuration/monitoring/index.html
@@ -699,12 +699,13 @@
       document.getElementById('activeDataFeedCount').innerHTML = activeDataFeedCount;
       let newActiveDataFeedsHtml = '';
       for (let i = 0; i < activeDataFeedCount; i++) {
-        const { dapiName, updateParameters, dataFeedValue, dataFeedDetails, signedApiUrls } =
+        const { dataFeedId, dapiName, updateParameters, dataFeedValue, dataFeedDetails, signedApiUrls } =
           await airseekerRegistry.activeDataFeed(i);
         const { deviationReference, deviationThresholdInPercentage, heartbeatInterval } =
           decodeUpdateParameters(updateParameters);
         const { value, timestamp } = dataFeedValue;
         const dataFeed = {
+          dataFeedId,
           dapiName,
           updateParameters: {
             deviationReference: deviationReference.toString(),

--- a/local-test-configuration/scripts/initialize-chain.ts
+++ b/local-test-configuration/scripts/initialize-chain.ts
@@ -206,7 +206,7 @@ export const deploy = async (funderWallet: ethers.Wallet, provider: ethers.provi
     await tx.wait();
     tx = await airseekerRegistry
       .connect(deployerAndManager)
-      .setUpdateParametersWithDapiName(
+      .setDapiNameUpdateParameters(
         dapiName,
         ethers.utils.defaultAbiCoder.encode(
           ['uint256', 'uint256', 'uint256'],

--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -45,7 +45,7 @@ describe('chains schema', () => {
       '31337': {
         contracts: {
           Api3ServerV1: '0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512',
-          AirseekerRegistry: '0xDD78254f864F97f65e2d86541BdaEf88A504D2B2',
+          AirseekerRegistry: '0x9fe46736679d2d9a65f0992f2272de9f3c7fa6e0',
         },
         providers: {
           hardhat: {
@@ -62,7 +62,7 @@ describe('chains schema', () => {
 
     expect(parsed['31337']!.contracts).toStrictEqual({
       Api3ServerV1: '0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512',
-      AirseekerRegistry: '0xDD78254f864F97f65e2d86541BdaEf88A504D2B2',
+      AirseekerRegistry: '0x9fe46736679d2d9a65f0992f2272de9f3c7fa6e0',
     });
   });
 
@@ -78,7 +78,7 @@ describe('chains schema', () => {
         dataFeedBatchSize: 10,
         dataFeedUpdateInterval: 60,
         contracts: {
-          AirseekerRegistry: '0xDD78254f864F97f65e2d86541BdaEf88A504D2B2',
+          AirseekerRegistry: '0x9fe46736679d2d9a65f0992f2272de9f3c7fa6e0',
         },
       },
     };
@@ -87,7 +87,7 @@ describe('chains schema', () => {
 
     expect(parsed['1']!.contracts).toStrictEqual({
       Api3ServerV1: '0x709944a48cAf83535e43471680fDA4905FB3920a',
-      AirseekerRegistry: '0xDD78254f864F97f65e2d86541BdaEf88A504D2B2',
+      AirseekerRegistry: '0x9fe46736679d2d9a65f0992f2272de9f3c7fa6e0',
     });
   });
 
@@ -100,7 +100,7 @@ describe('chains schema', () => {
           },
         },
         contracts: {
-          AirseekerRegistry: '0xDD78254f864F97f65e2d86541BdaEf88A504D2B2',
+          AirseekerRegistry: '0x9fe46736679d2d9a65f0992f2272de9f3c7fa6e0',
         },
         gasSettings,
         dataFeedBatchSize: 10,
@@ -124,7 +124,7 @@ describe('chains schema', () => {
       '31337': {
         contracts: {
           Api3ServerV1: '0xInvalid',
-          AirseekerRegistry: '0xDD78254f864F97f65e2d86541BdaEf88A504D2B2',
+          AirseekerRegistry: '0x9fe46736679d2d9a65f0992f2272de9f3c7fa6e0',
         },
         providers: {
           hardhat: {
@@ -168,7 +168,7 @@ describe('chains schema', () => {
       '31337': {
         contracts: {
           Api3ServerV1: '0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512',
-          AirseekerRegistry: '0xDD78254f864F97f65e2d86541BdaEf88A504D2B2',
+          AirseekerRegistry: '0x9fe46736679d2d9a65f0992f2272de9f3c7fa6e0',
         },
         providers: {},
         gasSettings,

--- a/src/update-feeds-loops/contracts.ts
+++ b/src/update-feeds-loops/contracts.ts
@@ -37,9 +37,9 @@ export const decodeDataFeedDetails = (dataFeed: string): DecodedDataFeed | null 
   // https://github.com/api3dao/dapi-management/blob/f3d39e4707c33c075a8f07aa8f8369f8dc07736f/contracts/AirseekerRegistry.sol#L209
   if (dataFeed === '0x') return null;
 
-  if (dataFeed.length === 130) {
-    // (64 [actual bytes] * 2[hex encoding] ) + 2 [for the '0x' preamble]
     // This is a hex encoded string, the contract works with bytes directly
+  // 2 characters for the '0x' preamble + 32 * 2 hexadecimals for 32 bytes + 32 * 2 hexadecimals for 32 bytes
+  if (dataFeed.length === 2 + 32 * 2 + 32 * 2) {
     const [airnodeAddress, templateId] = ethers.utils.defaultAbiCoder.decode(['address', 'bytes32'], dataFeed);
 
     const dataFeedId = deriveBeaconId(airnodeAddress, templateId)!;

--- a/src/update-feeds-loops/contracts.ts
+++ b/src/update-feeds-loops/contracts.ts
@@ -37,7 +37,7 @@ export const decodeDataFeedDetails = (dataFeed: string): DecodedDataFeed | null 
   // https://github.com/api3dao/dapi-management/blob/f3d39e4707c33c075a8f07aa8f8369f8dc07736f/contracts/AirseekerRegistry.sol#L209
   if (dataFeed === '0x') return null;
 
-    // This is a hex encoded string, the contract works with bytes directly
+  // This is a hex encoded string, the contract works with bytes directly
   // 2 characters for the '0x' preamble + 32 * 2 hexadecimals for 32 bytes + 32 * 2 hexadecimals for 32 bytes
   if (dataFeed.length === 2 + 32 * 2 + 32 * 2) {
     const [airnodeAddress, templateId] = ethers.utils.defaultAbiCoder.decode(['address', 'bytes32'], dataFeed);
@@ -73,6 +73,10 @@ export const decodeUpdateParameters = (updateParameters: string): DecodedUpdateP
     ['uint256', 'int224', 'uint256'],
     updateParameters
   );
+  // 2 characters for the '0x' preamble + 3 parameters, 32 * 2 hexadecimals for 32 bytes each
+  if (updateParameters.length !== 2 + 3 * (32 * 2)) {
+    throw new Error(`Unexpected trailing data in update parameters`);
+  }
 
   return {
     deviationReference,

--- a/src/update-feeds-loops/update-feeds-loops.test.ts
+++ b/src/update-feeds-loops/update-feeds-loops.test.ts
@@ -160,7 +160,7 @@ describe(updateFeedsLoopsModule.runUpdateFeeds.name, () => {
         dataFeedUpdateInterval: 10,
         providers: { ['provider-name']: { url: 'provider-url' } },
         contracts: {
-          AirseekerRegistry: '0xDD78254f864F97f65e2d86541BdaEf88A504D2B2',
+          AirseekerRegistry: '0x9fe46736679d2d9a65f0992f2272de9f3c7fa6e0',
         },
       }),
       '123'
@@ -249,7 +249,7 @@ describe(updateFeedsLoopsModule.runUpdateFeeds.name, () => {
         dataFeedUpdateInterval: 0.15,
         providers: { ['provider-name']: { url: 'provider-url' } },
         contracts: {
-          AirseekerRegistry: '0xDD78254f864F97f65e2d86541BdaEf88A504D2B2',
+          AirseekerRegistry: '0x9fe46736679d2d9a65f0992f2272de9f3c7fa6e0',
         },
       }),
       '31337'
@@ -325,7 +325,7 @@ describe(updateFeedsLoopsModule.runUpdateFeeds.name, () => {
         dataFeedUpdateInterval: 0.1,
         providers: { ['provider-name']: { url: 'provider-url' } },
         contracts: {
-          AirseekerRegistry: '0xDD78254f864F97f65e2d86541BdaEf88A504D2B2',
+          AirseekerRegistry: '0x9fe46736679d2d9a65f0992f2272de9f3c7fa6e0',
         },
       }),
       '31337'

--- a/test/fixtures/mock-config.ts
+++ b/test/fixtures/mock-config.ts
@@ -9,7 +9,7 @@ export const generateTestConfig = (): Config => ({
     '31337': {
       contracts: {
         Api3ServerV1: '0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512',
-        AirseekerRegistry: '0xDD78254f864F97f65e2d86541BdaEf88A504D2B2',
+        AirseekerRegistry: '0x9fe46736679d2d9a65f0992f2272de9f3c7fa6e0',
       },
       providers: { hardhat: { url: 'http://127.0.0.1:8545' } },
       gasSettings: {


### PR DESCRIPTION
I made two changes to AirseekerRegistry:
- I decided that the contract logic wasn't perfectly unambiguous and the data feed ID and dAPI name-based interfaces/storage have to be separated properly. Had to change one line of e2e test setup for this.
- https://github.com/api3dao/dapi-management/blob/8470f78f829c69f871fd1988217c47eab209f222/contracts/AirseekerRegistry.sol#L340 was weird so I had `activeDataFeed()` also return `dataFeedId`. The current airseeker-v2 implementation derives the data feed ID from `dataFeedDetails`, which is fine to keep as is.