### PR TITLE
Read beacon values directly from AirseekerRegistry contract

### DIFF
--- a/local-test-configuration/README.md
+++ b/local-test-configuration/README.md
@@ -72,10 +72,8 @@ also required for the monitoring page.
 The `AIRSEEKER_MNEMONIC` needs to be URI encoded via `encodeURIComponent` in JS. For example,
 `test%20test%20test%20test%20test%20test%20test%20test%20test%20test%20test%20junk`.
 
-Initially, you should see errors because the beacons are not initialized. After you run Airseeker, it will do the
-updates and the errors should be gone. The page constantly polls the chain and respective signed APIs and compares the
-on-chain and off-chain values. If the deviation exceeds the treshold, the value is marked bold and should be updated by
-Airseeker shortly.
+The page constantly polls the chain and respective signed APIs and compares the on-chain and off-chain values. If the
+deviation exceeds the treshold, the value is marked bold and should be updated by Airseeker shortly.
 
 - Run the Airseeker:
 

--- a/local-test-configuration/monitoring/index.html
+++ b/local-test-configuration/monitoring/index.html
@@ -888,7 +888,7 @@
           dataFeedValue: dataFeedValue.toString(),
           dataFeedTimestamp: dataFeedTimestamp.toString(),
           // This slightly differs from the main logic in Airseeker, but we only care about beacon IDs here.
-          beacons,
+          beacons: decodeDataFeedDetails(dataFeedDetails),
           signedApiUrls,
         };
         console.info('Data feed', dataFeed); // For debugging purposes.
@@ -911,7 +911,7 @@
         const sponsorWallet = deriveSponsorWallet(airseekerMnemonic, dapiName ?? dataFeed.dataFeedId);
         const dataFeedInfo = {
           dapiName: dapiName,
-          dataFeedId: dataFeed.decodedDataFeed.dataFeedId,
+          dataFeedId: dataFeed.dataFeedId,
           decodedDapiName: ethers.decodeBytes32String(dapiName),
           dataFeedValue: dataFeed.dataFeedValue,
           offChainValue: {

--- a/local-test-configuration/monitoring/index.html
+++ b/local-test-configuration/monitoring/index.html
@@ -744,14 +744,18 @@
     }
 
     const decodeDataFeedDetails = (dataFeed) => {
-      if (dataFeed.length === 130) {
-        // (64 [actual bytes] * 2[hex encoding] ) + 2 [for the '0x' preamble]
-        // This is a hex encoded string, the contract works with bytes directly
+      // The contract returns empty bytes if the data feed is not registered. See:
+      // https://github.com/bbenligiray/api3-contracts/blob/d394581549e4d2f343e9910bc330b21266808851/contracts/AirseekerRegistry.sol#L346
+      if (dataFeed === '0x') return null;
+
+      // This is a hex encoded string, the contract works with bytes directly
+      // 2 characters for the '0x' preamble + 32 * 2 hexadecimals for 32 bytes + 32 * 2 hexadecimals for 32 bytes
+      if (dataFeed.length === 2 + 32 * 2 + 32 * 2) {
         const [airnodeAddress, templateId] = ethers.AbiCoder.defaultAbiCoder().decode(['address', 'bytes32'], dataFeed);
 
         const dataFeedId = deriveBeaconId(airnodeAddress, templateId);
 
-        return { beacons: [{ beaconId: dataFeedId, airnodeAddress, templateId }] };
+        return [{ beaconId: dataFeedId, airnodeAddress, templateId }];
       }
 
       const [airnodeAddresses, templateIds] = ethers.AbiCoder.defaultAbiCoder().decode(
@@ -766,7 +770,7 @@
         return { beaconId, airnodeAddress, templateId };
       });
 
-      return { beacons };
+      return beacons;
     };
 
     const decodeUpdateParameters = (updateParameters) => {
@@ -883,7 +887,8 @@
           },
           dataFeedValue: dataFeedValue.toString(),
           dataFeedTimestamp: dataFeedTimestamp.toString(),
-          decodedDataFeed: decodeDataFeedDetails(dataFeedDetails),
+          // This slightly differs from the main logic in Airseeker, but we only care about beacon IDs here.
+          beacons,
           signedApiUrls,
         };
         console.info('Data feed', dataFeed); // For debugging purposes.
@@ -891,9 +896,9 @@
         let signedDatas = [];
         for (let i = 0; i < signedApiUrls.length; i++) {
           const url = signedApiUrls[i].replace('host.docker.internal', 'localhost');
-          const airnode = dataFeed.decodedDataFeed.beacons[i].airnodeAddress;
+          const airnode = dataFeed.beacons[i].airnodeAddress;
           const signedApiResponse = await fetch(`${url}/${airnode}`).then((res) => res.json());
-          const signedData = signedApiResponse.data[dataFeed.decodedDataFeed.beacons[i].beaconId];
+          const signedData = signedApiResponse.data[dataFeed.beacons[i].beaconId];
           signedDatas.push({ ...signedData, value: decodeBeaconValue(signedData.encodedValue).toString() });
         }
         console.info('Signed datas', signedDatas); // For debugging purposes.

--- a/local-test-configuration/monitoring/index.html
+++ b/local-test-configuration/monitoring/index.html
@@ -743,10 +743,6 @@
       return ethers.solidityPackedKeccak256(['address', 'bytes32'], [airnodeAddress, templateId]);
     }
 
-    function deriveBeaconSetId(beaconIds) {
-      return ethers.keccak256(ethers.AbiCoder.defaultAbiCoder().encode(['bytes32[]'], [beaconIds]));
-    }
-
     const decodeDataFeedDetails = (dataFeed) => {
       if (dataFeed.length === 130) {
         // (64 [actual bytes] * 2[hex encoding] ) + 2 [for the '0x' preamble]
@@ -755,7 +751,7 @@
 
         const dataFeedId = deriveBeaconId(airnodeAddress, templateId);
 
-        return { dataFeedId, beacons: [{ beaconId: dataFeedId, airnodeAddress, templateId }] };
+        return { beacons: [{ beaconId: dataFeedId, airnodeAddress, templateId }] };
       }
 
       const [airnodeAddresses, templateIds] = ethers.AbiCoder.defaultAbiCoder().decode(
@@ -770,9 +766,7 @@
         return { beaconId, airnodeAddress, templateId };
       });
 
-      const dataFeedId = deriveBeaconSetId(beacons.map((b) => b.beaconId));
-
-      return { dataFeedId, beacons };
+      return { beacons };
     };
 
     const decodeUpdateParameters = (updateParameters) => {
@@ -909,7 +903,7 @@
 
         const deviationPercentage = Number(calculateUpdateInPercentage(dataFeedValue, newBeaconSetValue)) / 1e6;
         const deviationThresholdPercentage = Number(deviationThresholdInPercentage) / 1e6;
-        const sponsorWallet = deriveSponsorWallet(airseekerMnemonic, dapiName ?? dataFeed.decodedDataFeed.dataFeedId);
+        const sponsorWallet = deriveSponsorWallet(airseekerMnemonic, dapiName ?? dataFeed.dataFeedId);
         const dataFeedInfo = {
           dapiName: dapiName,
           dataFeedId: dataFeed.decodedDataFeed.dataFeedId,

--- a/renovate.json
+++ b/renovate.json
@@ -14,13 +14,13 @@
     {
       "matchDepTypes": ["devDependencies"],
       "matchUpdateTypes": ["patch", "minor"],
-      "schedule": ["before 1am on the first day of the month"],
+      "schedule": ["before 4am on Monday"],
       "groupName": "non-major-dev-dependencies"
     },
     {
       "matchDepTypes": ["dependencies"],
       "matchUpdateTypes": ["patch", "minor"],
-      "schedule": ["before 1am on the first day of the month"],
+      "schedule": ["before 4am on Monday"],
       "groupName": "non-major-dependencies"
     }
   ],

--- a/src/deployment/cloudformation-template.json
+++ b/src/deployment/cloudformation-template.json
@@ -5,7 +5,7 @@
     "CloudWatchLogsGroup": {
       "Type": "AWS::Logs::LogGroup",
       "Properties": {
-        "LogGroupName": "AirseekerLogGroup",
+        "LogGroupName": "AirseekerLogGroup-<SOME_ID>",
         "RetentionInDays": 7
       }
     },
@@ -32,7 +32,7 @@
               },
               {
                 "Name": "LOG_LEVEL",
-                "Value": "debug"
+                "Value": "info"
               }
             ],
             "EntryPoint": [

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,13 +26,3 @@ export const signedApiResponseSchema = z.object({
   count: z.number().positive(),
   data: z.record(signedDataSchema),
 });
-
-export interface Beacon {
-  airnodeAddress: AirnodeAddress;
-  templateId: TemplateId;
-  beaconId: string;
-}
-
-export interface DecodedDataFeed {
-  beacons: Beacon[];
-}

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,6 +34,5 @@ export interface Beacon {
 }
 
 export interface DecodedDataFeed {
-  dataFeedId: string;
   beacons: Beacon[];
 }

--- a/src/update-feeds-loops/contracts.test.ts
+++ b/src/update-feeds-loops/contracts.test.ts
@@ -27,7 +27,6 @@ describe('helper functions', () => {
     const decodedResultMultiple = decodeDataFeedDetails(multiple);
 
     expect(decodedResultSingle).toStrictEqual({
-      dataFeedId: '0xf5c140bcb4814dfec311d38f6293e86c02d32ba1b7da027fe5b5202cae35dbc6',
       beacons: [
         {
           airnodeAddress: '0xc52EeA00154B4fF1EbbF8Ba39FDe37F1AC3B9Fd4',
@@ -37,7 +36,6 @@ describe('helper functions', () => {
       ],
     });
     expect(decodedResultMultiple).toStrictEqual({
-      dataFeedId: '0xfcb594f05d31036e4eb0884f2dd1130eced8f1aa09e00bda642fee3668ffd170',
       beacons: [
         {
           airnodeAddress: '0xc52EeA00154B4fF1EbbF8Ba39FDe37F1AC3B9Fd4',

--- a/src/update-feeds-loops/contracts.test.ts
+++ b/src/update-feeds-loops/contracts.test.ts
@@ -26,28 +26,24 @@ describe('helper functions', () => {
     const decodedResultSingle = decodeDataFeedDetails(single);
     const decodedResultMultiple = decodeDataFeedDetails(multiple);
 
-    expect(decodedResultSingle).toStrictEqual({
-      beacons: [
-        {
-          airnodeAddress: '0xc52EeA00154B4fF1EbbF8Ba39FDe37F1AC3B9Fd4',
-          beaconId: '0xf5c140bcb4814dfec311d38f6293e86c02d32ba1b7da027fe5b5202cae35dbc6',
-          templateId: '0x457a3b3da67e394a895ea49e534a4d91b2d009477bef15eab8cbed313925b010',
-        },
-      ],
-    });
-    expect(decodedResultMultiple).toStrictEqual({
-      beacons: [
-        {
-          airnodeAddress: '0xc52EeA00154B4fF1EbbF8Ba39FDe37F1AC3B9Fd4',
-          beaconId: '0xf5c140bcb4814dfec311d38f6293e86c02d32ba1b7da027fe5b5202cae35dbc6',
-          templateId: '0x457a3b3da67e394a895ea49e534a4d91b2d009477bef15eab8cbed313925b010',
-        },
-        {
-          airnodeAddress: '0xc52EeA00154B4fF1EbbF8Ba39FDe37F1AC3B9Fd4',
-          beaconId: '0xf5c140bcb4814dfec311d38f6293e86c02d32ba1b7da027fe5b5202cae35dbc6',
-          templateId: '0x457a3b3da67e394a895ea49e534a4d91b2d009477bef15eab8cbed313925b010',
-        },
-      ],
-    });
+    expect(decodedResultSingle).toStrictEqual([
+      {
+        airnodeAddress: '0xc52EeA00154B4fF1EbbF8Ba39FDe37F1AC3B9Fd4',
+        beaconId: '0xf5c140bcb4814dfec311d38f6293e86c02d32ba1b7da027fe5b5202cae35dbc6',
+        templateId: '0x457a3b3da67e394a895ea49e534a4d91b2d009477bef15eab8cbed313925b010',
+      },
+    ]);
+    expect(decodedResultMultiple).toStrictEqual([
+      {
+        airnodeAddress: '0xc52EeA00154B4fF1EbbF8Ba39FDe37F1AC3B9Fd4',
+        beaconId: '0xf5c140bcb4814dfec311d38f6293e86c02d32ba1b7da027fe5b5202cae35dbc6',
+        templateId: '0x457a3b3da67e394a895ea49e534a4d91b2d009477bef15eab8cbed313925b010',
+      },
+      {
+        airnodeAddress: '0xc52EeA00154B4fF1EbbF8Ba39FDe37F1AC3B9Fd4',
+        beaconId: '0xf5c140bcb4814dfec311d38f6293e86c02d32ba1b7da027fe5b5202cae35dbc6',
+        templateId: '0x457a3b3da67e394a895ea49e534a4d91b2d009477bef15eab8cbed313925b010',
+      },
+    ]);
   });
 });

--- a/src/update-feeds-loops/contracts.ts
+++ b/src/update-feeds-loops/contracts.ts
@@ -1,11 +1,12 @@
 import { ethers } from 'ethers';
+import { zip } from 'lodash';
 
 import {
-  Api3ServerV1__factory as Api3ServerV1Factory,
   type AirseekerRegistry,
   AirseekerRegistry__factory as AirseekerRegistryFactory,
+  Api3ServerV1__factory as Api3ServerV1Factory,
 } from '../typechain-types';
-import type { DecodedDataFeed } from '../types';
+import type { AirnodeAddress, TemplateId } from '../types';
 import { decodeDapiName, deriveBeaconId } from '../utils';
 
 export const getApi3ServerV1 = (address: string, provider: ethers.JsonRpcProvider) =>
@@ -29,9 +30,15 @@ export const decodeGetBlockNumberResponse = Number;
 
 export const decodeGetChainIdResponse = Number;
 
-export const decodeDataFeedDetails = (dataFeed: string): DecodedDataFeed | null => {
+export interface Beacon {
+  airnodeAddress: AirnodeAddress;
+  templateId: TemplateId;
+  beaconId: string;
+}
+
+export const decodeDataFeedDetails = (dataFeed: string): Beacon[] | null => {
   // The contract returns empty bytes if the data feed is not registered. See:
-  // https://github.com/api3dao/dapi-management/blob/f3d39e4707c33c075a8f07aa8f8369f8dc07736f/contracts/AirseekerRegistry.sol#L209
+  // https://github.com/bbenligiray/api3-contracts/blob/d394581549e4d2f343e9910bc330b21266808851/contracts/AirseekerRegistry.sol#L346
   if (dataFeed === '0x') return null;
 
   // This is a hex encoded string, the contract works with bytes directly
@@ -41,7 +48,7 @@ export const decodeDataFeedDetails = (dataFeed: string): DecodedDataFeed | null 
 
     const dataFeedId = deriveBeaconId(airnodeAddress, templateId)!;
 
-    return { beacons: [{ beaconId: dataFeedId, airnodeAddress, templateId }] };
+    return [{ beaconId: dataFeedId, airnodeAddress, templateId }];
   }
 
   const [airnodeAddresses, templateIds] = ethers.AbiCoder.defaultAbiCoder().decode(
@@ -56,7 +63,7 @@ export const decodeDataFeedDetails = (dataFeed: string): DecodedDataFeed | null 
     return { beaconId, airnodeAddress, templateId };
   });
 
-  return { beacons };
+  return beacons;
 };
 
 export interface DecodedUpdateParameters {
@@ -81,6 +88,11 @@ export const decodeUpdateParameters = (updateParameters: string): DecodedUpdateP
   };
 };
 
+export interface BeaconWithData extends Beacon {
+  value: bigint;
+  timestamp: bigint;
+}
+
 export interface DecodedActiveDataFeedResponse {
   dapiName: string | null;
   dataFeedId: string;
@@ -88,22 +100,41 @@ export interface DecodedActiveDataFeedResponse {
   decodedUpdateParameters: DecodedUpdateParameters;
   dataFeedValue: bigint;
   dataFeedTimestamp: bigint;
-  decodedDataFeed: DecodedDataFeed;
+  beaconsWithData: BeaconWithData[];
   signedApiUrls: string[];
 }
+
+export const createBeaconsWithData = (beacons: Beacon[], beaconValues: bigint[], beaconTimestamps: bigint[]) => {
+  return zip(beacons, beaconValues, beaconTimestamps).map(([beacon, value, timestamp]) => ({
+    ...beacon!,
+    value: value!,
+    timestamp: BigInt(timestamp!),
+  }));
+};
 
 export const decodeActiveDataFeedResponse = (
   airseekerRegistry: AirseekerRegistry,
   activeDataFeedReturndata: string
 ): DecodedActiveDataFeedResponse | null => {
-  const { dapiName, dataFeedId, updateParameters, dataFeedValue, dataFeedTimestamp, dataFeedDetails, signedApiUrls } =
-    airseekerRegistry.interface.decodeFunctionResult('activeDataFeed', activeDataFeedReturndata) as unknown as Awaited<
-      ReturnType<AirseekerRegistry['activeDataFeed']['staticCall']>
-    >;
+  const {
+    dataFeedId,
+    dapiName,
+    updateParameters,
+    dataFeedValue,
+    dataFeedTimestamp,
+    dataFeedDetails,
+    signedApiUrls,
+    beaconValues,
+    beaconTimestamps,
+  } = airseekerRegistry.interface.decodeFunctionResult(
+    'activeDataFeed',
+    activeDataFeedReturndata
+  ) as unknown as Awaited<ReturnType<AirseekerRegistry['activeDataFeed']['staticCall']>>;
 
-  // https://github.com/api3dao/dapi-management/blob/f3d39e4707c33c075a8f07aa8f8369f8dc07736f/contracts/AirseekerRegistry.sol#L162
-  const decodedDataFeed = decodeDataFeedDetails(dataFeedDetails);
-  if (!decodedDataFeed) return null;
+  // https://github.com/bbenligiray/api3-contracts/blob/d394581549e4d2f343e9910bc330b21266808851/contracts/AirseekerRegistry.sol#L295
+  const beacons = decodeDataFeedDetails(dataFeedDetails);
+  if (!beacons) return null;
+  const beaconsWithData = createBeaconsWithData(beacons, beaconValues, beaconTimestamps);
 
   // The dAPI name will be set to zero (in bytes32) in case the data feed is not a dAPI and is identified by a data feed
   // ID.
@@ -116,7 +147,7 @@ export const decodeActiveDataFeedResponse = (
     decodedUpdateParameters: decodeUpdateParameters(updateParameters),
     dataFeedValue,
     dataFeedTimestamp,
-    decodedDataFeed,
+    beaconsWithData,
     signedApiUrls,
   };
 };

--- a/src/update-feeds-loops/get-updatable-feeds.test.ts
+++ b/src/update-feeds-loops/get-updatable-feeds.test.ts
@@ -8,20 +8,8 @@ import { updateState } from '../state';
 import type { BeaconId, SignedData } from '../types';
 import { encodeDapiName } from '../utils';
 
-import * as contractsModule from './contracts';
-import { multicallBeaconValues, getUpdatableFeeds } from './get-updatable-feeds';
-import * as getUpdatableFeedsModule from './get-updatable-feeds';
-
-const chainId = '31337';
-const rpcUrl = 'http://127.0.0.1:8545/';
-const provider = new ethers.JsonRpcProvider(
-  rpcUrl,
-  {
-    chainId: Number.parseInt(chainId, 10),
-    name: chainId,
-  },
-  { staticNetwork: true }
-);
+import type * as contractsModule from './contracts';
+import { getUpdatableFeeds } from './get-updatable-feeds';
 
 // https://github.com/api3dao/airnode-protocol-v1/blob/fa95f043ce4b50e843e407b96f7ae3edcf899c32/contracts/api3-server-v1/DataFeedServer.sol#L132
 const encodeBeaconValue = (numericValue: string) => {
@@ -36,59 +24,6 @@ const feedIds = [
   '0xf5c140bcb4814dfec311d38f6293e86c02d32ba1b7da027fe5b5202cae35dbc8',
 ] as const;
 
-describe(multicallBeaconValues.name, () => {
-  beforeEach(() => {
-    initializeState();
-  });
-
-  it('calls and parses a multicall', async () => {
-    const tryMulticallMock = jest.fn().mockReturnValue({
-      successes: [true, true, true],
-      returndata: [
-        ethers.AbiCoder.defaultAbiCoder().encode(['uint256'], [31_337]),
-        ethers.AbiCoder.defaultAbiCoder().encode(['int224', 'uint32'], [100, 105]),
-        ethers.AbiCoder.defaultAbiCoder().encode(['int224', 'uint32'], [101, 106]),
-        ethers.AbiCoder.defaultAbiCoder().encode(['int224', 'uint32'], [102, 107]),
-      ],
-    });
-
-    const encodeFunctionDataMock = jest.fn();
-    encodeFunctionDataMock.mockReturnValueOnce('0xChain');
-    encodeFunctionDataMock.mockReturnValueOnce('0xFirst');
-    encodeFunctionDataMock.mockReturnValueOnce('0xSecond');
-    encodeFunctionDataMock.mockReturnValueOnce('0xThird');
-
-    const mockContract = {
-      connect: jest.fn().mockReturnValue({
-        tryMulticall: {
-          staticCall: tryMulticallMock,
-        },
-      }),
-      interface: { encodeFunctionData: encodeFunctionDataMock },
-    };
-
-    jest.spyOn(contractsModule, 'getApi3ServerV1').mockReturnValue(mockContract as any);
-
-    const callAndParseMulticallPromise = await multicallBeaconValues(feedIds as unknown as string[], provider, '31337');
-
-    expect(callAndParseMulticallPromise).toStrictEqual({
-      '0xf5c140bcb4814dfec311d38f6293e86c02d32ba1b7da027fe5b5202cae35dbc6': {
-        timestamp: 105n,
-        value: 100n,
-      },
-      '0xf5c140bcb4814dfec311d38f6293e86c02d32ba1b7da027fe5b5202cae35dbc7': {
-        timestamp: 106n,
-        value: 101n,
-      },
-      '0xf5c140bcb4814dfec311d38f6293e86c02d32ba1b7da027fe5b5202cae35dbc8': {
-        timestamp: 107n,
-        value: 102n,
-      },
-    });
-    expect(tryMulticallMock).toHaveBeenCalledWith(['0xChain', '0xFirst', '0xSecond', '0xThird']);
-  });
-});
-
 describe(getUpdatableFeeds.name, () => {
   beforeEach(() => {
     initializeState();
@@ -101,7 +36,7 @@ describe(getUpdatableFeeds.name, () => {
     });
   });
 
-  it('returns updatable feeds when value exceeds the threshold', async () => {
+  it('returns updatable feeds when value exceeds the threshold', () => {
     jest.useFakeTimers().setSystemTime(90);
 
     // Only the third feed will satisfy the timestamp check
@@ -122,22 +57,6 @@ describe(getUpdatableFeeds.name, () => {
     jest
       .spyOn(signedDataStateModule, 'getSignedData')
       .mockImplementation((dataFeedId: string) => mockSignedDataState[dataFeedId]!);
-
-    // None of the feeds failed to update
-    jest.spyOn(getUpdatableFeedsModule, 'multicallBeaconValues').mockResolvedValue({
-      '0xf5c140bcb4814dfec311d38f6293e86c02d32ba1b7da027fe5b5202cae35dbc6': {
-        timestamp: 150n,
-        value: BigInt('400'),
-      },
-      '0xf5c140bcb4814dfec311d38f6293e86c02d32ba1b7da027fe5b5202cae35dbc7': {
-        timestamp: 160n,
-        value: BigInt('500'),
-      },
-      '0xf5c140bcb4814dfec311d38f6293e86c02d32ba1b7da027fe5b5202cae35dbc8': {
-        timestamp: 170n,
-        value: BigInt('600'),
-      },
-    });
     jest.spyOn(logger, 'info');
 
     const batch = allowPartial<contractsModule.DecodedActiveDataFeedResponse[]>([
@@ -148,15 +67,17 @@ describe(getUpdatableFeeds.name, () => {
         },
         dataFeedValue: 10n,
         dataFeedTimestamp: 95n,
-        decodedDataFeed: {
-          beacons: [{ beaconId: feedIds[0] }, { beaconId: feedIds[1] }, { beaconId: feedIds[2] }],
-        },
+        beaconsWithData: [
+          { beaconId: feedIds[0], timestamp: BigInt(150), value: BigInt('400') },
+          { beaconId: feedIds[1], timestamp: BigInt(160), value: BigInt('500') },
+          { beaconId: feedIds[2], timestamp: BigInt(170), value: BigInt('600') },
+        ],
         dataFeedId: '0x000',
         dapiName: encodeDapiName('test'),
       },
     ]);
 
-    const checkFeedsResult = await getUpdatableFeeds(batch, 1, provider, '31337');
+    const checkFeedsResult = getUpdatableFeeds(batch, 1);
 
     expect(logger.info).toHaveBeenCalledWith(`Deviation exceeded.`);
     expect(checkFeedsResult).toStrictEqual([
@@ -175,19 +96,17 @@ describe(getUpdatableFeeds.name, () => {
           dataFeedId: '0x000',
           dataFeedValue: BigInt('10'),
           dataFeedTimestamp: 95n,
-          decodedDataFeed: {
-            beacons: [
-              expect.objectContaining({
-                beaconId: '0xf5c140bcb4814dfec311d38f6293e86c02d32ba1b7da027fe5b5202cae35dbc6',
-              }),
-              expect.objectContaining({
-                beaconId: '0xf5c140bcb4814dfec311d38f6293e86c02d32ba1b7da027fe5b5202cae35dbc7',
-              }),
-              expect.objectContaining({
-                beaconId: '0xf5c140bcb4814dfec311d38f6293e86c02d32ba1b7da027fe5b5202cae35dbc8',
-              }),
-            ],
-          },
+          beaconsWithData: [
+            expect.objectContaining({
+              beaconId: '0xf5c140bcb4814dfec311d38f6293e86c02d32ba1b7da027fe5b5202cae35dbc6',
+            }),
+            expect.objectContaining({
+              beaconId: '0xf5c140bcb4814dfec311d38f6293e86c02d32ba1b7da027fe5b5202cae35dbc7',
+            }),
+            expect.objectContaining({
+              beaconId: '0xf5c140bcb4814dfec311d38f6293e86c02d32ba1b7da027fe5b5202cae35dbc8',
+            }),
+          ],
           decodedUpdateParameters: {
             deviationThresholdInPercentage: 1n,
             heartbeatInterval: 100n,
@@ -197,7 +116,7 @@ describe(getUpdatableFeeds.name, () => {
     ]);
   });
 
-  it('returns updatable feeds when on chain timestamp is older than heartbeat and value is within the deviation', async () => {
+  it('returns updatable feeds when on chain timestamp is older than heartbeat and value is within the deviation', () => {
     jest.useFakeTimers().setSystemTime(500_000);
 
     // Only the third feed will satisfy the timestamp check
@@ -218,22 +137,6 @@ describe(getUpdatableFeeds.name, () => {
     jest
       .spyOn(signedDataStateModule, 'getSignedData')
       .mockImplementation((dataFeedId: string) => mockSignedDataState[dataFeedId]!);
-
-    // None of the feeds failed to update
-    jest.spyOn(getUpdatableFeedsModule, 'multicallBeaconValues').mockResolvedValue({
-      '0xf5c140bcb4814dfec311d38f6293e86c02d32ba1b7da027fe5b5202cae35dbc6': {
-        timestamp: 150n,
-        value: BigInt('400'),
-      },
-      '0xf5c140bcb4814dfec311d38f6293e86c02d32ba1b7da027fe5b5202cae35dbc7': {
-        timestamp: 160n,
-        value: BigInt('400'),
-      },
-      '0xf5c140bcb4814dfec311d38f6293e86c02d32ba1b7da027fe5b5202cae35dbc8': {
-        timestamp: 170n,
-        value: BigInt('400'),
-      },
-    });
     jest.spyOn(logger, 'debug');
 
     const batch = allowPartial<contractsModule.DecodedActiveDataFeedResponse[]>([
@@ -244,15 +147,17 @@ describe(getUpdatableFeeds.name, () => {
         },
         dataFeedValue: 400n,
         dataFeedTimestamp: 90n,
-        decodedDataFeed: {
-          beacons: [{ beaconId: feedIds[0] }, { beaconId: feedIds[1] }, { beaconId: feedIds[2] }],
-        },
+        beaconsWithData: [
+          { beaconId: feedIds[0], timestamp: BigInt(150), value: BigInt('400') },
+          { beaconId: feedIds[1], timestamp: BigInt(160), value: BigInt('400') },
+          { beaconId: feedIds[2], timestamp: BigInt(170), value: BigInt('400') },
+        ],
         dataFeedId: '0x000',
         dapiName: encodeDapiName('test'),
       },
     ]);
 
-    const checkFeedsResult = await getUpdatableFeeds(batch, 1, provider, '31337');
+    const checkFeedsResult = getUpdatableFeeds(batch, 1);
 
     expect(logger.debug).toHaveBeenCalledWith(`On-chain timestamp is older than the heartbeat interval.`);
     expect(checkFeedsResult).toStrictEqual([
@@ -271,19 +176,17 @@ describe(getUpdatableFeeds.name, () => {
           dataFeedId: '0x000',
           dataFeedValue: BigInt('400'),
           dataFeedTimestamp: 90n,
-          decodedDataFeed: {
-            beacons: [
-              expect.objectContaining({
-                beaconId: '0xf5c140bcb4814dfec311d38f6293e86c02d32ba1b7da027fe5b5202cae35dbc6',
-              }),
-              expect.objectContaining({
-                beaconId: '0xf5c140bcb4814dfec311d38f6293e86c02d32ba1b7da027fe5b5202cae35dbc7',
-              }),
-              expect.objectContaining({
-                beaconId: '0xf5c140bcb4814dfec311d38f6293e86c02d32ba1b7da027fe5b5202cae35dbc8',
-              }),
-            ],
-          },
+          beaconsWithData: [
+            expect.objectContaining({
+              beaconId: '0xf5c140bcb4814dfec311d38f6293e86c02d32ba1b7da027fe5b5202cae35dbc6',
+            }),
+            expect.objectContaining({
+              beaconId: '0xf5c140bcb4814dfec311d38f6293e86c02d32ba1b7da027fe5b5202cae35dbc7',
+            }),
+            expect.objectContaining({
+              beaconId: '0xf5c140bcb4814dfec311d38f6293e86c02d32ba1b7da027fe5b5202cae35dbc8',
+            }),
+          ],
           decodedUpdateParameters: {
             deviationThresholdInPercentage: 1n,
             heartbeatInterval: 1n,
@@ -293,7 +196,7 @@ describe(getUpdatableFeeds.name, () => {
     ]);
   });
 
-  it('returns an empty array for old fulfillment data', async () => {
+  it('returns an empty array for old fulfillment data', () => {
     jest.useFakeTimers().setSystemTime(150);
 
     // Mock signed data state to have stale data
@@ -324,38 +227,24 @@ describe(getUpdatableFeeds.name, () => {
         },
         dataFeedValue: 200n,
         dataFeedTimestamp: 160n,
-        decodedDataFeed: {
-          beacons: [{ beaconId: feedIds[0] }, { beaconId: feedIds[1] }, { beaconId: feedIds[2] }],
-        },
+        beaconsWithData: [
+          { beaconId: feedIds[0], timestamp: BigInt(150), value: BigInt('200') },
+          { beaconId: feedIds[1], timestamp: BigInt(155), value: BigInt('200') },
+          { beaconId: feedIds[2], timestamp: BigInt(170), value: BigInt('200') },
+        ],
         dataFeedId: '0x000',
         dapiName: encodeDapiName('test'),
       },
     ]);
-
-    // Ensure on-chain values don't trigger an update
-    jest.spyOn(getUpdatableFeedsModule, 'multicallBeaconValues').mockResolvedValue({
-      '0xf5c140bcb4814dfec311d38f6293e86c02d32ba1b7da027fe5b5202cae35dbc6': {
-        timestamp: 150n,
-        value: BigInt('200'),
-      },
-      '0xf5c140bcb4814dfec311d38f6293e86c02d32ba1b7da027fe5b5202cae35dbc7': {
-        timestamp: 155n,
-        value: BigInt('200'),
-      },
-      '0xf5c140bcb4814dfec311d38f6293e86c02d32ba1b7da027fe5b5202cae35dbc8': {
-        timestamp: 170n,
-        value: BigInt('200'),
-      },
-    });
     jest.spyOn(logger, 'warn');
 
-    const checkFeedsResult = await getUpdatableFeeds(batch, 1, provider, '31337');
+    const checkFeedsResult = getUpdatableFeeds(batch, 1);
 
     expect(logger.warn).toHaveBeenCalledWith(`Off-chain sample's timestamp is older than on-chain timestamp.`);
     expect(checkFeedsResult).toStrictEqual([]);
   });
 
-  it('returns an empty array for on chain data newer than heartbeat and value within the threshold', async () => {
+  it('returns an empty array for on chain data newer than heartbeat and value within the threshold', () => {
     jest.useFakeTimers().setSystemTime(90);
 
     // Only the third feed will satisfy the timestamp check
@@ -376,22 +265,6 @@ describe(getUpdatableFeeds.name, () => {
     jest
       .spyOn(signedDataStateModule, 'getSignedData')
       .mockImplementation((dataFeedId: string) => mockSignedDataState[dataFeedId]!);
-
-    // None of the feeds failed to update
-    jest.spyOn(getUpdatableFeedsModule, 'multicallBeaconValues').mockResolvedValue({
-      '0xf5c140bcb4814dfec311d38f6293e86c02d32ba1b7da027fe5b5202cae35dbc6': {
-        timestamp: 150n,
-        value: BigInt('400'),
-      },
-      '0xf5c140bcb4814dfec311d38f6293e86c02d32ba1b7da027fe5b5202cae35dbc7': {
-        timestamp: 160n,
-        value: BigInt('400'),
-      },
-      '0xf5c140bcb4814dfec311d38f6293e86c02d32ba1b7da027fe5b5202cae35dbc8': {
-        timestamp: 170n,
-        value: BigInt('400'),
-      },
-    });
     jest.spyOn(logger, 'info');
 
     const batch = allowPartial<contractsModule.DecodedActiveDataFeedResponse[]>([
@@ -402,48 +275,20 @@ describe(getUpdatableFeeds.name, () => {
         },
         dataFeedValue: 400n,
         dataFeedTimestamp: 140n,
-        decodedDataFeed: {
-          beacons: [{ beaconId: feedIds[0] }, { beaconId: feedIds[1] }, { beaconId: feedIds[2] }],
-        },
+        beaconsWithData: [
+          { beaconId: feedIds[0], timestamp: BigInt(150), value: BigInt('400') },
+          { beaconId: feedIds[1], timestamp: BigInt(160), value: BigInt('400') },
+          { beaconId: feedIds[2], timestamp: BigInt(170), value: BigInt('400') },
+        ],
         dataFeedId: '0x000',
         dapiName: encodeDapiName('test'),
       },
     ]);
 
-    const checkFeedsResult = await getUpdatableFeeds(batch, 1, provider, '31337');
+    const checkFeedsResult = getUpdatableFeeds(batch, 1);
 
     expect(logger.info).not.toHaveBeenCalledWith(`Deviation exceeded.`);
     expect(logger.info).not.toHaveBeenCalledWith(`On-chain timestamp is older than the heartbeat interval.`);
-    expect(checkFeedsResult).toStrictEqual([]);
-  });
-
-  it('handles multicall failure', async () => {
-    const batch = allowPartial<contractsModule.DecodedActiveDataFeedResponse[]>([
-      {
-        decodedUpdateParameters: {
-          deviationThresholdInPercentage: 1n,
-          heartbeatInterval: 100n,
-        },
-        dataFeedValue: 10n,
-        dataFeedTimestamp: 95n,
-        decodedDataFeed: {
-          beacons: [{ beaconId: feedIds[0] }, { beaconId: feedIds[1] }, { beaconId: feedIds[2] }],
-        },
-        dapiName: encodeDapiName('test'),
-        dataFeedId: '0x000',
-        decodedDapiName: 'test',
-      },
-    ]);
-    jest.spyOn(getUpdatableFeedsModule, 'multicallBeaconValues').mockRejectedValueOnce(new Error('Multicall failed'));
-    jest.spyOn(logger, 'error');
-
-    const checkFeedsResult = await getUpdatableFeeds(batch, 1, provider, '31337');
-
-    expect(logger.error).toHaveBeenCalledWith(
-      `Multicalling on-chain data feed values has failed. Skipping update for all data feeds in a batch`,
-      new Error('Multicall failed'),
-      { dapiNames: ['test'], dataFeedIds: ['0x000'] }
-    );
     expect(checkFeedsResult).toStrictEqual([]);
   });
 });

--- a/src/update-feeds-loops/get-updatable-feeds.test.ts
+++ b/src/update-feeds-loops/get-updatable-feeds.test.ts
@@ -149,9 +149,9 @@ describe(getUpdatableFeeds.name, () => {
         dataFeedValue: 10n,
         dataFeedTimestamp: 95n,
         decodedDataFeed: {
-          dataFeedId: '0x000',
           beacons: [{ beaconId: feedIds[0] }, { beaconId: feedIds[1] }, { beaconId: feedIds[2] }],
         },
+        dataFeedId: '0x000',
         dapiName: encodeDapiName('test'),
       },
     ]);
@@ -172,6 +172,7 @@ describe(getUpdatableFeeds.name, () => {
         ],
         dataFeedInfo: {
           dapiName: encodeDapiName('test'),
+          dataFeedId: '0x000',
           dataFeedValue: BigInt('10'),
           dataFeedTimestamp: 95n,
           decodedDataFeed: {
@@ -186,7 +187,6 @@ describe(getUpdatableFeeds.name, () => {
                 beaconId: '0xf5c140bcb4814dfec311d38f6293e86c02d32ba1b7da027fe5b5202cae35dbc8',
               }),
             ],
-            dataFeedId: '0x000',
           },
           decodedUpdateParameters: {
             deviationThresholdInPercentage: 1n,
@@ -245,9 +245,9 @@ describe(getUpdatableFeeds.name, () => {
         dataFeedValue: 400n,
         dataFeedTimestamp: 90n,
         decodedDataFeed: {
-          dataFeedId: '0x000',
           beacons: [{ beaconId: feedIds[0] }, { beaconId: feedIds[1] }, { beaconId: feedIds[2] }],
         },
+        dataFeedId: '0x000',
         dapiName: encodeDapiName('test'),
       },
     ]);
@@ -268,6 +268,7 @@ describe(getUpdatableFeeds.name, () => {
         ],
         dataFeedInfo: {
           dapiName: encodeDapiName('test'),
+          dataFeedId: '0x000',
           dataFeedValue: BigInt('400'),
           dataFeedTimestamp: 90n,
           decodedDataFeed: {
@@ -282,7 +283,6 @@ describe(getUpdatableFeeds.name, () => {
                 beaconId: '0xf5c140bcb4814dfec311d38f6293e86c02d32ba1b7da027fe5b5202cae35dbc8',
               }),
             ],
-            dataFeedId: '0x000',
           },
           decodedUpdateParameters: {
             deviationThresholdInPercentage: 1n,
@@ -325,9 +325,9 @@ describe(getUpdatableFeeds.name, () => {
         dataFeedValue: 200n,
         dataFeedTimestamp: 160n,
         decodedDataFeed: {
-          dataFeedId: '0x000',
           beacons: [{ beaconId: feedIds[0] }, { beaconId: feedIds[1] }, { beaconId: feedIds[2] }],
         },
+        dataFeedId: '0x000',
         dapiName: encodeDapiName('test'),
       },
     ]);
@@ -403,9 +403,9 @@ describe(getUpdatableFeeds.name, () => {
         dataFeedValue: 400n,
         dataFeedTimestamp: 140n,
         decodedDataFeed: {
-          dataFeedId: '0x000',
           beacons: [{ beaconId: feedIds[0] }, { beaconId: feedIds[1] }, { beaconId: feedIds[2] }],
         },
+        dataFeedId: '0x000',
         dapiName: encodeDapiName('test'),
       },
     ]);
@@ -427,10 +427,10 @@ describe(getUpdatableFeeds.name, () => {
         dataFeedValue: 10n,
         dataFeedTimestamp: 95n,
         decodedDataFeed: {
-          dataFeedId: '0x000',
           beacons: [{ beaconId: feedIds[0] }, { beaconId: feedIds[1] }, { beaconId: feedIds[2] }],
         },
         dapiName: encodeDapiName('test'),
+        dataFeedId: '0x000',
         decodedDapiName: 'test',
       },
     ]);

--- a/src/update-feeds-loops/get-updatable-feeds.ts
+++ b/src/update-feeds-loops/get-updatable-feeds.ts
@@ -1,19 +1,9 @@
-import { go } from '@api3/promise-utils';
-import { ethers } from 'ethers';
-
 import { getSignedData } from '../data-fetcher-loop/signed-data-state';
 import { calculateMedian, isDataFeedUpdatable } from '../deviation-check';
-import { logger } from '../logger';
-import { getState } from '../state';
-import type { BeaconId, ChainId, SignedData } from '../types';
+import type { SignedData } from '../types';
 import { decodeBeaconValue, multiplyBigNumber } from '../utils';
 
-import {
-  getApi3ServerV1,
-  type DecodedActiveDataFeedResponse,
-  decodeGetChainIdResponse,
-  verifyMulticallResponse,
-} from './contracts';
+import type { DecodedActiveDataFeedResponse } from './contracts';
 
 interface BeaconValue {
   timestamp: bigint;
@@ -30,36 +20,16 @@ export interface UpdatableDataFeed {
   updatableBeacons: UpdatableBeacon[];
 }
 
-export const getUpdatableFeeds = async (
+export const getUpdatableFeeds = (
   batch: DecodedActiveDataFeedResponse[],
-  deviationThresholdCoefficient: number,
-  provider: ethers.JsonRpcProvider,
-  chainId: ChainId
-): Promise<UpdatableDataFeed[]> => {
-  const uniqueBeaconIds = [
-    ...new Set(batch.flatMap((item) => item.decodedDataFeed.beacons.flatMap((beacon) => beacon.beaconId))),
-  ];
-  const goOnChainFeedValues = await go(async () => multicallBeaconValues(uniqueBeaconIds, provider, chainId));
-  if (!goOnChainFeedValues.success) {
-    logger.error(
-      `Multicalling on-chain data feed values has failed. Skipping update for all data feeds in a batch`,
-      goOnChainFeedValues.error,
-      {
-        dapiNames: batch.map((dataFeed) => dataFeed.decodedDapiName),
-        dataFeedIds: batch.map((dataFeed) => dataFeed.dataFeedId),
-      }
-    );
-    return [];
-  }
-  const onChainFeedValues = goOnChainFeedValues.data;
-  if (!onChainFeedValues) return [];
-
+  deviationThresholdCoefficient: number
+): UpdatableDataFeed[] => {
   return (
     batch
       // Determine on-chain and off-chain values for each beacon.
       .map((dataFeedInfo) => {
-        const beaconsWithData = dataFeedInfo.decodedDataFeed.beacons.map(({ beaconId }) => {
-          const onChainValue: BeaconValue = onChainFeedValues[beaconId]!;
+        const aggregatedBeaconsWithData = dataFeedInfo.beaconsWithData.map(({ beaconId, timestamp, value }) => {
+          const onChainValue: BeaconValue = { timestamp, value };
           const signedData = getSignedData(beaconId);
           const offChainValue: BeaconValue | undefined = signedData
             ? {
@@ -74,12 +44,12 @@ export const getUpdatableFeeds = async (
 
         return {
           dataFeedInfo,
-          beaconsWithData,
+          aggregatedBeaconsWithData,
         };
       })
       // Filter out data feeds that cannot be updated.
-      .filter(({ dataFeedInfo, beaconsWithData }) => {
-        const beaconValues = beaconsWithData.map(({ onChainValue, offChainValue, isUpdatable }) =>
+      .filter(({ dataFeedInfo, aggregatedBeaconsWithData }) => {
+        const beaconValues = aggregatedBeaconsWithData.map(({ onChainValue, offChainValue, isUpdatable }) =>
           isUpdatable ? offChainValue! : onChainValue
         );
 
@@ -102,9 +72,9 @@ export const getUpdatableFeeds = async (
         );
       })
       // Compute the updateable beacons.
-      .map(({ dataFeedInfo, beaconsWithData }) => ({
+      .map(({ dataFeedInfo, aggregatedBeaconsWithData }) => ({
         dataFeedInfo,
-        updatableBeacons: beaconsWithData
+        updatableBeacons: aggregatedBeaconsWithData
           .filter(({ isUpdatable }) => isUpdatable)
           .map(({ beaconId, signedData }) => ({
             beaconId,
@@ -112,44 +82,4 @@ export const getUpdatableFeeds = async (
           })),
       }))
   );
-};
-
-export const multicallBeaconValues = async (
-  batch: BeaconId[],
-  provider: ethers.JsonRpcProvider,
-  chainId: ChainId
-): Promise<Record<BeaconId, BeaconValue> | null> => {
-  const { config } = getState();
-  const chain = config.chains[chainId]!;
-  const { contracts } = chain;
-
-  // Calling the dataFeeds contract function is guaranteed not to revert, so we are not checking the multicall successes
-  // and using returndata directly. If the call fails (e.g. timeout or RPC error) we let the parent handle it.
-  const api3ServerV1 = getApi3ServerV1(contracts.Api3ServerV1, provider);
-  const voidSigner = new ethers.VoidSigner(ethers.ZeroAddress, provider);
-  const returndatas = verifyMulticallResponse(
-    await api3ServerV1
-      .connect(voidSigner)
-      .tryMulticall.staticCall([
-        api3ServerV1.interface.encodeFunctionData('getChainId'),
-        ...batch.map((beaconId) => api3ServerV1.interface.encodeFunctionData('dataFeeds', [beaconId])),
-      ])
-  );
-  const [chainIdReturndata, ...dataFeedsReturndata] = returndatas;
-
-  const contractChainId = decodeGetChainIdResponse(chainIdReturndata!).toString();
-  if (contractChainId !== chainId) {
-    logger.warn(`Chain ID mismatch.`, { chainId, contractChainId });
-    return null;
-  }
-
-  const onChainValues: Record<BeaconId, BeaconValue> = {};
-  for (const [idx, beaconId] of batch.entries()) {
-    const [value, timestamp] = ethers.AbiCoder.defaultAbiCoder().decode(
-      ['int224', 'uint32'],
-      dataFeedsReturndata[idx]!
-    );
-    onChainValues[beaconId] = { timestamp: BigInt(timestamp), value: BigInt(value) };
-  }
-  return onChainValues;
 };

--- a/src/update-feeds-loops/get-updatable-feeds.ts
+++ b/src/update-feeds-loops/get-updatable-feeds.ts
@@ -46,7 +46,7 @@ export const getUpdatableFeeds = async (
       goOnChainFeedValues.error,
       {
         dapiNames: batch.map((dataFeed) => dataFeed.decodedDapiName),
-        dataFeedIds: batch.map((dataFeed) => dataFeed.decodedDataFeed.dataFeedId),
+        dataFeedIds: batch.map((dataFeed) => dataFeed.dataFeedId),
       }
     );
     return [];

--- a/src/update-feeds-loops/submit-transactions.test.ts
+++ b/src/update-feeds-loops/submit-transactions.test.ts
@@ -73,13 +73,11 @@ describe(submitTransactionsModule.createUpdateFeedCalldatas.name, () => {
           },
         ],
         dataFeedInfo: {
-          decodedDataFeed: {
-            beacons: [
-              {
-                beaconId: '0xf5c140bcb4814dfec311d38f6293e86c02d32ba1b7da027fe5b5202cae35dbc8',
-              },
-            ],
-          },
+          beaconsWithData: [
+            {
+              beaconId: '0xf5c140bcb4814dfec311d38f6293e86c02d32ba1b7da027fe5b5202cae35dbc8',
+            },
+          ],
         },
       })
     );
@@ -134,19 +132,17 @@ describe(submitTransactionsModule.createUpdateFeedCalldatas.name, () => {
           },
         ],
         dataFeedInfo: {
-          decodedDataFeed: {
-            beacons: [
-              {
-                beaconId: '0xf5c140bcb4814dfec311d38f6293e86c02d32ba1b7da027fe5b5202cae35dbc6',
-              },
-              {
-                beaconId: '0xf5c140bcb4814dfec311d38f6293e86c02d32ba1b7da027fe5b5202cae35dbc7',
-              },
-              {
-                beaconId: '0xf5c140bcb4814dfec311d38f6293e86c02d32ba1b7da027fe5b5202cae35dbc8',
-              },
-            ],
-          },
+          beaconsWithData: [
+            {
+              beaconId: '0xf5c140bcb4814dfec311d38f6293e86c02d32ba1b7da027fe5b5202cae35dbc6',
+            },
+            {
+              beaconId: '0xf5c140bcb4814dfec311d38f6293e86c02d32ba1b7da027fe5b5202cae35dbc7',
+            },
+            {
+              beaconId: '0xf5c140bcb4814dfec311d38f6293e86c02d32ba1b7da027fe5b5202cae35dbc8',
+            },
+          ],
         },
       })
     );
@@ -202,19 +198,17 @@ describe(submitTransactionsModule.createUpdateFeedCalldatas.name, () => {
           },
         ],
         dataFeedInfo: {
-          decodedDataFeed: {
-            beacons: [
-              {
-                beaconId: '0xf5c140bcb4814dfec311d38f6293e86c02d32ba1b7da027fe5b5202cae35dbc6',
-              },
-              {
-                beaconId: '0xf5c140bcb4814dfec311d38f6293e86c02d32ba1b7da027fe5b5202cae35dbc7',
-              },
-              {
-                beaconId: '0xf5c140bcb4814dfec311d38f6293e86c02d32ba1b7da027fe5b5202cae35dbc8',
-              },
-            ],
-          },
+          beaconsWithData: [
+            {
+              beaconId: '0xf5c140bcb4814dfec311d38f6293e86c02d32ba1b7da027fe5b5202cae35dbc6',
+            },
+            {
+              beaconId: '0xf5c140bcb4814dfec311d38f6293e86c02d32ba1b7da027fe5b5202cae35dbc7',
+            },
+            {
+              beaconId: '0xf5c140bcb4814dfec311d38f6293e86c02d32ba1b7da027fe5b5202cae35dbc8',
+            },
+          ],
         },
       })
     );

--- a/src/update-feeds-loops/submit-transactions.test.ts
+++ b/src/update-feeds-loops/submit-transactions.test.ts
@@ -355,9 +355,7 @@ describe(submitTransactionsModule.submitTransaction.name, () => {
       allowPartial<UpdatableDataFeed>({
         dataFeedInfo: {
           dapiName,
-          decodedDataFeed: {
-            dataFeedId: '0xBeaconSetId',
-          },
+          dataFeedId: '0xBeaconSetId',
         },
       }),
       123_456

--- a/src/update-feeds-loops/submit-transactions.ts
+++ b/src/update-feeds-loops/submit-transactions.ts
@@ -56,11 +56,7 @@ export const submitTransaction = async (
   } = state;
 
   const { dataFeedInfo } = updatableDataFeed;
-  const {
-    dapiName,
-    decodedDapiName,
-    decodedDataFeed: { dataFeedId },
-  } = dataFeedInfo;
+  const { dapiName, dataFeedId, decodedDapiName } = dataFeedInfo;
   const { dataFeedUpdateInterval, fallbackGasLimit } = chains[chainId]!;
   const dataFeedUpdateIntervalMs = dataFeedUpdateInterval * 1000;
 

--- a/src/update-feeds-loops/submit-transactions.ts
+++ b/src/update-feeds-loops/submit-transactions.ts
@@ -12,7 +12,7 @@ import type { UpdatableDataFeed } from './get-updatable-feeds';
 
 export const createUpdateFeedCalldatas = (api3ServerV1: Api3ServerV1, updatableDataFeed: UpdatableDataFeed) => {
   const { dataFeedInfo, updatableBeacons } = updatableDataFeed;
-  const allBeacons = dataFeedInfo.decodedDataFeed.beacons;
+  const allBeacons = dataFeedInfo.beaconsWithData;
 
   // Create calldata for beacons that need to be updated.
   const beaconUpdateCalls = updatableBeacons.map(({ signedData }) =>

--- a/src/update-feeds-loops/update-feeds-loops.ts
+++ b/src/update-feeds-loops/update-feeds-loops.ts
@@ -258,7 +258,7 @@ export const processBatch = async (
 ) => {
   logger.debug('Processing batch of active data feeds.', {
     dapiNames: batch.map((dataFeed) => dataFeed.decodedDapiName),
-    dataFeedIds: batch.map((dataFeed) => dataFeed.decodedDataFeed.dataFeedId),
+    dataFeedIds: batch.map((dataFeed) => dataFeed.dataFeedId),
     blockNumber,
   });
   const {
@@ -285,18 +285,13 @@ export const processBatch = async (
 
   // Clear last update timestamps for feeds that don't need an update
   for (const feed of batch) {
-    const {
-      dapiName,
-      decodedDapiName,
-      decodedDataFeed: { dataFeedId },
-    } = feed;
+    const { dapiName, dataFeedId, decodedDapiName } = feed;
 
     // Skip if the data feed is updatable
     if (
       feedsToUpdate.some(
         (updatableFeed) =>
-          updatableFeed.dataFeedInfo.dapiName === dapiName &&
-          updatableFeed.dataFeedInfo.decodedDataFeed.dataFeedId === dataFeedId
+          updatableFeed.dataFeedInfo.dapiName === dapiName && updatableFeed.dataFeedInfo.dataFeedId === dataFeedId
       )
     ) {
       continue;

--- a/src/update-feeds-loops/update-feeds-loops.ts
+++ b/src/update-feeds-loops/update-feeds-loops.ts
@@ -268,7 +268,7 @@ export const processBatch = async (
 
   updateState((draft) => {
     for (const dataFeed of batch) {
-      const receivedUrls = zip(dataFeed.signedApiUrls, dataFeed.decodedDataFeed.beacons).map(([url, beacon]) => ({
+      const receivedUrls = zip(dataFeed.signedApiUrls, dataFeed.beaconsWithData).map(([url, beacon]) => ({
         url: `${url}/${beacon!.airnodeAddress}`,
         airnodeAddress: beacon!.airnodeAddress,
       }));
@@ -281,7 +281,7 @@ export const processBatch = async (
     }
   });
 
-  const feedsToUpdate = await getUpdatableFeeds(batch, deviationThresholdCoefficient, provider, chainId);
+  const feedsToUpdate = getUpdatableFeeds(batch, deviationThresholdCoefficient);
 
   // Clear last update timestamps for feeds that don't need an update
   for (const feed of batch) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -11,10 +11,6 @@ export function deriveBeaconId(airnodeAddress: string, templateId: string) {
   return goSync(() => ethers.solidityPackedKeccak256(['address', 'bytes32'], [airnodeAddress, templateId])).data;
 }
 
-export function deriveBeaconSetId(beaconIds: string[]) {
-  return goSync(() => ethers.keccak256(ethers.AbiCoder.defaultAbiCoder().encode(['bytes32[]'], [beaconIds]))).data;
-}
-
 export const encodeDapiName = (decodedDapiName: string) => ethers.encodeBytes32String(decodedDapiName);
 
 export const decodeDapiName = (encodedDapiName: string) => ethers.decodeBytes32String(encodedDapiName);

--- a/test/e2e/update-feeds.feature.ts
+++ b/test/e2e/update-feeds.feature.ts
@@ -2,7 +2,11 @@ import { initializeGasState } from '../../src/gas-price';
 import { logger } from '../../src/logger';
 import * as stateModule from '../../src/state';
 import { runUpdateFeeds } from '../../src/update-feeds-loops';
-import { decodeDataFeedDetails, decodeUpdateParameters } from '../../src/update-feeds-loops/contracts';
+import {
+  createBeaconsWithData,
+  decodeDataFeedDetails,
+  decodeUpdateParameters,
+} from '../../src/update-feeds-loops/contracts';
 import { submitTransactions } from '../../src/update-feeds-loops/submit-transactions';
 import { decodeDapiName } from '../../src/utils';
 import { initializeState } from '../fixtures/mock-config';
@@ -43,10 +47,19 @@ it('updates blockchain data', async () => {
     draft.config.sponsorWalletMnemonic = airseekerWallet.mnemonic!.phrase;
   });
   initializeGasState(chainId, providerName);
-  const { dataFeedId, dapiName, dataFeedDetails, dataFeedValue, dataFeedTimestamp, updateParameters, signedApiUrls } =
-    await airseekerRegistry.activeDataFeed(0);
+  const {
+    dataFeedId,
+    dapiName,
+    dataFeedDetails,
+    dataFeedValue,
+    dataFeedTimestamp,
+    updateParameters,
+    signedApiUrls,
+    beaconValues,
+    beaconTimestamps,
+  } = await airseekerRegistry.activeDataFeed(0);
 
-  const decodedDataFeed = decodeDataFeedDetails(dataFeedDetails)!;
+  const beacons = decodeDataFeedDetails(dataFeedDetails)!;
   const activeBtcDataFeed = {
     dapiName,
     dataFeedId,
@@ -54,7 +67,7 @@ it('updates blockchain data', async () => {
     dataFeedTimestamp,
     signedApiUrls,
     decodedUpdateParameters: decodeUpdateParameters(updateParameters),
-    decodedDataFeed,
+    beaconsWithData: createBeaconsWithData(beacons, beaconValues, beaconTimestamps),
     decodedDapiName: decodeDapiName(dapiName),
   };
 

--- a/test/fixtures/mock-contract.ts
+++ b/test/fixtures/mock-contract.ts
@@ -18,6 +18,8 @@ export const generateActiveDataFeedResponse = () => ({
     airnodeAddress: '0xc52EeA00154B4fF1EbbF8Ba39FDe37F1AC3B9Fd4',
     templateId: '0x457a3b3da67e394a895ea49e534a4d91b2d009477bef15eab8cbed313925b010',
   }),
+  beaconValues: [BigInt(123 * 1e6)],
+  beaconTimestamps: [1_629_811_200n],
   signedApiUrls: ['http://localhost:8080'],
 });
 

--- a/test/fixtures/mock-contract.ts
+++ b/test/fixtures/mock-contract.ts
@@ -6,6 +6,7 @@ import { type DeepPartial, encodeBeaconDetails } from '../utils';
 
 export const generateActiveDataFeedResponse = () => ({
   dapiName: encodeDapiName('MOCK_FEED'),
+  dataFeedId: '0xf5c140bcb4814dfec311d38f6293e86c02d32ba1b7da027fe5b5202cae35dbc6',
   updateParameters: ethers.AbiCoder.defaultAbiCoder().encode(
     ['uint256', 'int224', 'uint256'],
     [0.5 * 1e8, 0.5 * 1e8, 100] // deviationThresholdInPercentage, deviationReference, heartbeatInterval

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -2,7 +2,8 @@ import { randomBytes } from 'node:crypto';
 
 import { ethers, type HDNodeWallet } from 'ethers';
 
-import type { SignedData, Beacon } from '../src/types';
+import type { SignedData } from '../src/types';
+import type { Beacon } from '../src/update-feeds-loops/contracts';
 
 export const signData = async (signer: ethers.Signer, templateId: string, timestamp: string, data: string) =>
   signer.signMessage(


### PR DESCRIPTION
Closes https://github.com/api3dao/airseeker-v2/issues/172

## Rationale

Build on top of https://github.com/api3dao/airseeker-v2/pull/178 which already adds the latest contracts, but does not migrate the logic (still multicalls the beacon values). This PR uses the values which are now returned when we read active data feeds. Also removes all extraneous code.

## TODO

- [x] Test local flow (there were a few rebase issues with the other branch)
- [x] Update spec