### PR TITLE
Self funded wallet derivation

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ The derivation scheme used to derive sponsor wallets. The following options are 
 
 - `self-funded` - The sponsor wallet is derived from the hash of the encoded beacon ID together with the update
   parameters. This is the scheme that was originally used by Nodary for self-funded data feeds.
+  <!-- TODO: Change to "managed" -->
 - `managed-dapis` - Derives the wallet from the hash of the dAPI name (or data feed ID). This means the wallet
   derivation is agnostic to update parameters, and the same wallet is used when the dAPI is upgraded/downgraded.
 

--- a/README.md
+++ b/README.md
@@ -224,6 +224,15 @@ The fetch interval in seconds between retrievals of signed API data.
 
 A list of signed API URLs to call along with URLs fetched from the chain.
 
+#### `walletDerivationScheme`
+
+The derivation scheme used to derive sponsor wallets. The following options are available:
+
+- `self-funded` - The sponsor wallet is derived from the hash of the encoded beacon ID together with the update
+  parameters. This is the scheme that was originally used by Nodary for self-funded data feeds.
+- `managed-dapis` - Derives the wallet from the hash of the dAPI name (or data feed ID). This means the wallet
+  derivation is agnostic to update parameters, and the same wallet is used when the dAPI is upgraded/downgraded.
+
 ## Docker
 
 ### Build

--- a/README.md
+++ b/README.md
@@ -230,9 +230,8 @@ The derivation scheme used to derive sponsor wallets. The following options are 
 
 - `self-funded` - The sponsor wallet is derived from the hash of the encoded beacon ID together with the update
   parameters. This is the scheme that was originally used by Nodary for self-funded data feeds.
-  <!-- TODO: Change to "managed" -->
-- `managed-dapis` - Derives the wallet from the hash of the dAPI name (or data feed ID). This means the wallet
-  derivation is agnostic to update parameters, and the same wallet is used when the dAPI is upgraded/downgraded.
+- `managed` - Derives the wallet from the hash of the dAPI name (or data feed ID). This means the wallet derivation is
+  agnostic to update parameters, and the same wallet is used when the dAPI is upgraded/downgraded.
 
 ## Docker
 

--- a/README.md
+++ b/README.md
@@ -226,7 +226,11 @@ A list of signed API URLs to call along with URLs fetched from the chain.
 
 #### `walletDerivationScheme`
 
-The derivation scheme used to derive sponsor wallets. The following options are available:
+The derivation scheme configuration used to derive sponsor wallets.
+
+##### `type`
+
+The following options are available:
 
 - `self-funded` - The sponsor wallet is derived from the hash of the encoded beacon ID together with the update
   parameters. This is the scheme that was originally used by Nodary for self-funded data feeds.

--- a/config/airseeker.example.json
+++ b/config/airseeker.example.json
@@ -25,5 +25,5 @@
   "deviationThresholdCoefficient": 1,
   "signedDataFetchInterval": 10,
   "signedApiUrls": [],
-  "walletDerivationScheme": "managed-dapis"
+  "walletDerivationScheme": "managed"
 }

--- a/config/airseeker.example.json
+++ b/config/airseeker.example.json
@@ -24,5 +24,6 @@
   },
   "deviationThresholdCoefficient": 1,
   "signedDataFetchInterval": 10,
-  "signedApiUrls": []
+  "signedApiUrls": [],
+  "walletDerivationScheme": "managed-dapis"
 }

--- a/config/airseeker.example.json
+++ b/config/airseeker.example.json
@@ -25,5 +25,5 @@
   "deviationThresholdCoefficient": 1,
   "signedDataFetchInterval": 10,
   "signedApiUrls": [],
-  "walletDerivationScheme": "managed"
+  "walletDerivationScheme": { "type": "managed" }
 }

--- a/local-test-configuration/README.md
+++ b/local-test-configuration/README.md
@@ -66,7 +66,7 @@ also required for the monitoring page.
 
 - Open the monitoring page located in `local-test-configuration/monitoring/index.html` in a browser with the following
   query parameters appended
-  `?airseekerRegistryAddress=<DEPLOYED_AIRSEEKER_REGISTRY_ADDRESS>&rpcUrl=<RPC_URL>&airseekerMnemonic=<AIRSEEKER_MNEMONIC>`
+  `?airseekerRegistryAddress=<DEPLOYED_AIRSEEKER_REGISTRY_ADDRESS>&rpcUrl=<RPC_URL>&airseekerMnemonic=<AIRSEEKER_MNEMONIC>&walletDerivationScheme=managed`
   and open console.
 
 The `AIRSEEKER_MNEMONIC` needs to be URI encoded via `encodeURIComponent` in JS. For example,

--- a/local-test-configuration/airseeker/airseeker.example.json
+++ b/local-test-configuration/airseeker/airseeker.example.json
@@ -25,5 +25,6 @@
   },
   "deviationThresholdCoefficient": 1,
   "signedDataFetchInterval": 10,
-  "signedApiUrls": []
+  "signedApiUrls": [],
+  "walletDerivationScheme": "managed"
 }

--- a/local-test-configuration/airseeker/airseeker.example.json
+++ b/local-test-configuration/airseeker/airseeker.example.json
@@ -26,5 +26,5 @@
   "deviationThresholdCoefficient": 1,
   "signedDataFetchInterval": 10,
   "signedApiUrls": [],
-  "walletDerivationScheme": "managed"
+  "walletDerivationScheme": { "type:": "managed" }
 }

--- a/local-test-configuration/monitoring/index.html
+++ b/local-test-configuration/monitoring/index.html
@@ -729,7 +729,8 @@
     const urlParams = new URLSearchParams(window.location.search);
     const rpcUrl = urlParams.get('rpcUrl'),
       airseekerRegistryAddress = urlParams.get('airseekerRegistryAddress'),
-      airseekerMnemonic = decodeURIComponent(urlParams.get('airseekerMnemonic'));
+      airseekerMnemonic = decodeURIComponent(urlParams.get('airseekerMnemonic')),
+      walletDerivationScheme = decodeURIComponent(urlParams.get('walletDerivationScheme'));
 
     if (!airseekerRegistryAddress) throw new Error('airseekerRegistryAddress must be provided as URL parameter');
     if (!airseekerMnemonic) throw new Error('airseekerMnemonic must be provided as URL parameter');
@@ -840,13 +841,19 @@
       return `${AIRSEEKER_PROTOCOL_ID}/${paths.join('/')}`;
     }
 
-    const deriveSponsorWallet = (sponsorWalletMnemonic, dapiNameOrDataFeedId) => {
-      // Hash the dAPI name or data feed ID because we need to take the first 20 bytes of it which could result in
-      // collisions for dAPIs with the same prefix.
-      const hashedDapiNameOrDataFeedId = ethers.keccak256(dapiNameOrDataFeedId);
+    const deriveSponsorAddressHashForManagedFeed = (dapiNameOrDataFeedId) => {
+      // Hashing the dAPI name is important because we need to take the first 20 bytes of the hash which could result in
+      // collisions for (encoded) dAPI names with the same prefix.
+      return ethers.keccak256(dapiNameOrDataFeedId);
+    };
 
-      // Take first 20 bytes of the hashed dapiName or data feed ID as sponsor address together with the "0x" prefix.
-      const sponsorAddress = ethers.getAddress(hashedDapiNameOrDataFeedId.slice(0, 42));
+    const deriveSponsorAddressHashForSelfFundedFeed = (dapiNameOrDataFeedId, updateParameters) => {
+      return ethers.keccak256(ethers.solidityPacked(['bytes32', 'bytes'], [dapiNameOrDataFeedId, updateParameters]));
+    };
+
+    const deriveSponsorWalletFromSponsorAddressHash = (sponsorWalletMnemonic, sponsorAddressHash) => {
+      // Take the first 20 bytes of the sponsor address hash + "0x" prefix.
+      const sponsorAddress = ethers.getAddress(sponsorAddressHash.slice(0, 42));
       // NOTE: Be sure not to use "ethers.Wallet.fromPhrase(sponsorWalletMnemonic).derivePath" because that produces a
       // different result.
       const sponsorWallet = ethers.HDNodeWallet.fromPhrase(
@@ -856,6 +863,23 @@
       );
 
       return sponsorWallet;
+    };
+
+    const deriveSponsorWallet = (
+      sponsorWalletMnemonic,
+      dapiNameOrDataFeedId,
+      updateParameters,
+      walletDerivationScheme
+    ) => {
+      // Derive the hash of the data feed using which the sponsor wallet is derived. For self-funded feeds it's more
+      // suitable to derive the hash also from update parameters. This does not apply to mananaged feeds which want to be
+      // funded by the same wallet independently of the update parameters.
+      const sponsorAddressHash =
+        walletDerivationScheme === 'self-funded'
+          ? deriveSponsorAddressHashForSelfFundedFeed(dapiNameOrDataFeedId, updateParameters)
+          : deriveSponsorAddressHashForManagedFeed(dapiNameOrDataFeedId);
+
+      return deriveSponsorWalletFromSponsorAddressHash(sponsorWalletMnemonic, sponsorAddressHash);
     };
 
     setInterval(async () => {
@@ -908,7 +932,12 @@
 
         const deviationPercentage = Number(calculateUpdateInPercentage(dataFeedValue, newBeaconSetValue)) / 1e6;
         const deviationThresholdPercentage = Number(deviationThresholdInPercentage) / 1e6;
-        const sponsorWallet = deriveSponsorWallet(airseekerMnemonic, dapiName ?? dataFeed.dataFeedId);
+        const sponsorWallet = deriveSponsorWallet(
+          airseekerMnemonic,
+          dapiName ?? dataFeed.dataFeedId,
+          updateParameters,
+          walletDerivationScheme
+        );
         const dataFeedInfo = {
           dapiName: dapiName,
           dataFeedId: dataFeed.dataFeedId,

--- a/local-test-configuration/monitoring/index.html
+++ b/local-test-configuration/monitoring/index.html
@@ -871,9 +871,11 @@
       updateParameters,
       walletDerivationScheme
     ) => {
-      // Derive the hash of the data feed using which the sponsor wallet is derived. For self-funded feeds it's more
-      // suitable to derive the hash also from update parameters. This does not apply to mananaged feeds which want to be
-      // funded by the same wallet independently of the update parameters.
+      // Derive the sponsor address hash, whose first 20 bytes are interpreted as the sponsor address. This address is used
+      // to derive the sponsor wallet.
+      //
+      // For self-funded feeds it's more suitable to derive the hash also from update parameters. This does not apply to
+      // mananaged feeds which want to be funded by the same wallet independently of the update parameters.
       const sponsorAddressHash =
         walletDerivationScheme === 'self-funded'
           ? deriveSponsorAddressHashForSelfFundedFeed(dapiNameOrDataFeedId, updateParameters)

--- a/local-test-configuration/scripts/initialize-chain.ts
+++ b/local-test-configuration/scripts/initialize-chain.ts
@@ -13,7 +13,12 @@ import {
   AccessControlRegistry__factory as AccessControlRegistryFactory,
   Api3ServerV1__factory as Api3ServerV1Factory,
 } from '../../src/typechain-types';
-import { deriveBeaconId, deriveSponsorWallet, encodeDapiName } from '../../src/utils';
+import {
+  deriveBeaconId,
+  deriveSponsorAddressHashForManagedFeed,
+  deriveSponsorWalletFromSponsorAddressHash,
+  encodeDapiName,
+} from '../../src/utils';
 
 interface RawBeaconData {
   airnodeAddress: string;
@@ -57,7 +62,11 @@ export const refundFunder = async (funderWallet: ethers.HDNodeWallet) => {
   for (const beaconSetName of getBeaconSetNames()) {
     const dapiName = encodeDapiName(beaconSetName);
 
-    const sponsorWallet = deriveSponsorWallet(airseekerWalletMnemonic, dapiName).connect(funderWallet.provider);
+    const sponsorAddressHash = deriveSponsorAddressHashForManagedFeed(dapiName);
+    const sponsorWallet = deriveSponsorWalletFromSponsorAddressHash(
+      airseekerWalletMnemonic,
+      sponsorAddressHash
+    ).connect(funderWallet.provider);
     const sponsorWalletBalance = await funderWallet.provider!.getBalance(sponsorWallet.address);
     console.info('Sponsor wallet balance:', ethers.formatEther(sponsorWalletBalance.toString()));
 
@@ -117,7 +126,8 @@ export const fundAirseekerSponsorWallet = async (funderWallet: ethers.HDNodeWall
   for (const beaconSetName of getBeaconSetNames()) {
     const dapiName = encodeDapiName(beaconSetName);
 
-    const sponsorWallet = deriveSponsorWallet(airseekerWalletMnemonic, dapiName);
+    const sponsorAddressHash = deriveSponsorAddressHashForManagedFeed(dapiName);
+    const sponsorWallet = deriveSponsorWalletFromSponsorAddressHash(airseekerWalletMnemonic, sponsorAddressHash);
     const sponsorWalletBalance = await funderWallet.provider!.getBalance(sponsorWallet.address);
     console.info('Sponsor wallet balance:', ethers.formatEther(sponsorWalletBalance.toString()));
 

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -135,7 +135,15 @@ export const deviationThresholdCoefficientSchema = z
 
 export type DeviationThresholdCoefficient = z.infer<typeof deviationThresholdCoefficientSchema>;
 
-export const walletDerivationSchemeSchema = z.union([z.literal('self-funded'), z.literal('managed')]);
+export const walletDerivationTypeSchema = z.union([z.literal('self-funded'), z.literal('managed')]);
+
+export type WalletDerivationType = z.infer<typeof walletDerivationTypeSchema>;
+
+export const walletDerivationSchemeSchema = z
+  .object({
+    type: walletDerivationTypeSchema,
+  })
+  .strict();
 
 export type WalletDerivationScheme = z.infer<typeof walletDerivationSchemeSchema>;
 

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -135,7 +135,7 @@ export const deviationThresholdCoefficientSchema = z
 
 export type DeviationThresholdCoefficient = z.infer<typeof deviationThresholdCoefficientSchema>;
 
-export const walletDerivationSchemeSchema = z.union([z.literal('self-funded'), z.literal('managed-dapis')]);
+export const walletDerivationSchemeSchema = z.union([z.literal('self-funded'), z.literal('managed')]);
 
 export type WalletDerivationScheme = z.infer<typeof walletDerivationSchemeSchema>;
 

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -135,6 +135,10 @@ export const deviationThresholdCoefficientSchema = z
 
 export type DeviationThresholdCoefficient = z.infer<typeof deviationThresholdCoefficientSchema>;
 
+export const walletDerivationSchemeSchema = z.union([z.literal('self-funded'), z.literal('managed-dapis')]);
+
+export type WalletDerivationScheme = z.infer<typeof walletDerivationSchemeSchema>;
+
 export const configSchema = z
   .object({
     sponsorWalletMnemonic: z
@@ -144,6 +148,7 @@ export const configSchema = z
     signedDataFetchInterval: z.number().positive(),
     deviationThresholdCoefficient: deviationThresholdCoefficientSchema,
     signedApiUrls: z.array(z.string().url()),
+    walletDerivationScheme: walletDerivationSchemeSchema,
   })
   .strict();
 

--- a/src/update-feeds-loops/contracts.ts
+++ b/src/update-feeds-loops/contracts.ts
@@ -94,10 +94,11 @@ export interface BeaconWithData extends Beacon {
 }
 
 export interface DecodedActiveDataFeedResponse {
-  dapiName: string | null;
-  dataFeedId: string;
+  dapiName: string | null; // NOTE: Encoded dAPI name
   decodedDapiName: string | null;
+  updateParameters: string; // NOTE: Encoded update parameters
   decodedUpdateParameters: DecodedUpdateParameters;
+  dataFeedId: string;
   dataFeedValue: bigint;
   dataFeedTimestamp: bigint;
   beaconsWithData: BeaconWithData[];
@@ -141,10 +142,11 @@ export const decodeActiveDataFeedResponse = (
   const decodedDapiName = decodeDapiName(dapiName);
 
   return {
-    dapiName: decodedDapiName === '' ? null : dapiName, // NOTE: Anywhere in the codebase the "dapiName" is the encoded version of the dAPI name.
-    dataFeedId,
+    dapiName: decodedDapiName === '' ? null : dapiName,
     decodedDapiName: decodedDapiName === '' ? null : decodedDapiName,
+    updateParameters,
     decodedUpdateParameters: decodeUpdateParameters(updateParameters),
+    dataFeedId,
     dataFeedValue,
     dataFeedTimestamp,
     beaconsWithData,

--- a/src/update-feeds-loops/submit-transactions.test.ts
+++ b/src/update-feeds-loops/submit-transactions.test.ts
@@ -248,7 +248,7 @@ describe(submitTransactionsModule.getDerivedSponsorWallet.name, () => {
         'some-mnemonic',
         dapiName,
         'does-not-matter',
-        'managed'
+        { type: 'managed' }
       );
 
       expect(utilsModule.deriveSponsorWallet).toHaveBeenCalledTimes(0);
@@ -269,7 +269,7 @@ describe(submitTransactionsModule.getDerivedSponsorWallet.name, () => {
         'diamond result history offer forest diagram crop armed stumble orchard stage glance',
         dapiName,
         'does-not-matter',
-        'managed'
+        { type: 'managed' }
       );
 
       expect(utilsModule.deriveSponsorWallet).toHaveBeenCalledTimes(1);
@@ -289,7 +289,7 @@ describe(submitTransactionsModule.getDerivedSponsorWallet.name, () => {
         'diamond result history offer forest diagram crop armed stumble orchard stage glance',
         '0x173ec7594911a9d584d577bc8e8b9bb546018667d820a67685df49201a11ae9b',
         'does-not-matter',
-        'managed'
+        { type: 'managed' }
       );
 
       expect(utilsModule.deriveSponsorWallet).toHaveBeenCalledTimes(1);
@@ -314,7 +314,7 @@ describe(submitTransactionsModule.getDerivedSponsorWallet.name, () => {
         'diamond result history offer forest diagram crop armed stumble orchard stage glance',
         dapiName,
         updateParameters,
-        'self-funded'
+        { type: 'self-funded' }
       );
 
       expect(utilsModule.deriveSponsorWallet).toHaveBeenCalledTimes(1);
@@ -368,6 +368,7 @@ describe(submitTransactionsModule.submitTransaction.name, () => {
               fallbackGasLimit: undefined,
             },
           },
+          walletDerivationScheme: { type: 'managed' },
           sponsorWalletMnemonic: 'diamond result history offer forest diagram crop armed stumble orchard stage glance',
         },
       })

--- a/src/update-feeds-loops/submit-transactions.test.ts
+++ b/src/update-feeds-loops/submit-transactions.test.ts
@@ -232,68 +232,94 @@ describe(submitTransactionsModule.createUpdateFeedCalldatas.name, () => {
 });
 
 describe(submitTransactionsModule.getDerivedSponsorWallet.name, () => {
-  it('returns the derived sponsor wallet for a dAPI', () => {
-    const dapiName = utilsModule.encodeDapiName('ETH/USD');
-    jest.spyOn(stateModule, 'getState').mockReturnValue(
-      allowPartial<stateModule.State>({
-        derivedSponsorWallets: {
-          [dapiName]: '0x034e238bdc2622122e7b2191ee5be5df38597b6f58e45b25c6d32cae3110ebfa',
-        },
-      })
-    );
-    jest.spyOn(utilsModule, 'deriveSponsorWallet');
+  describe('managed feeds', () => {
+    it('returns the derived sponsor wallet for a dAPI', () => {
+      const dapiName = utilsModule.encodeDapiName('ETH/USD');
+      jest.spyOn(stateModule, 'getState').mockReturnValue(
+        allowPartial<stateModule.State>({
+          derivedSponsorWallets: {
+            [dapiName]: '0x034e238bdc2622122e7b2191ee5be5df38597b6f58e45b25c6d32cae3110ebfa',
+          },
+        })
+      );
+      jest.spyOn(utilsModule, 'deriveSponsorWallet');
 
-    const sponsorWallet = submitTransactionsModule.getDerivedSponsorWallet(
-      'some-mnemonic',
-      dapiName,
-      'does-not-matter',
-      'managed'
-    );
+      const sponsorWallet = submitTransactionsModule.getDerivedSponsorWallet(
+        'some-mnemonic',
+        dapiName,
+        'does-not-matter',
+        'managed'
+      );
 
-    expect(utilsModule.deriveSponsorWallet).toHaveBeenCalledTimes(0);
-    expect(sponsorWallet.privateKey).toBe('0x034e238bdc2622122e7b2191ee5be5df38597b6f58e45b25c6d32cae3110ebfa');
+      expect(utilsModule.deriveSponsorWallet).toHaveBeenCalledTimes(0);
+      expect(sponsorWallet.privateKey).toBe('0x034e238bdc2622122e7b2191ee5be5df38597b6f58e45b25c6d32cae3110ebfa');
+    });
+
+    it('derives the sponsor wallet for a dAPI if it does not exist', () => {
+      const dapiName = utilsModule.encodeDapiName('ETH/USD');
+      jest.spyOn(stateModule, 'getState').mockReturnValue(
+        allowPartial<stateModule.State>({
+          derivedSponsorWallets: {},
+        })
+      );
+      jest.spyOn(stateModule, 'updateState').mockImplementation();
+      jest.spyOn(utilsModule, 'deriveSponsorWallet');
+
+      const sponsorWallet = submitTransactionsModule.getDerivedSponsorWallet(
+        'diamond result history offer forest diagram crop armed stumble orchard stage glance',
+        dapiName,
+        'does-not-matter',
+        'managed'
+      );
+
+      expect(utilsModule.deriveSponsorWallet).toHaveBeenCalledTimes(1);
+      expect(sponsorWallet.privateKey).toBe('0xd4cc2592775d876d6af59163bb7894272d84f538439e3c53af3bebdc0668b49d');
+    });
+
+    it('derives the sponsor wallet for a data feed ID if it does not exist', () => {
+      jest.spyOn(stateModule, 'getState').mockReturnValue(
+        allowPartial<stateModule.State>({
+          derivedSponsorWallets: {},
+        })
+      );
+      jest.spyOn(stateModule, 'updateState').mockImplementation();
+      jest.spyOn(utilsModule, 'deriveSponsorWallet');
+
+      const sponsorWallet = submitTransactionsModule.getDerivedSponsorWallet(
+        'diamond result history offer forest diagram crop armed stumble orchard stage glance',
+        '0x173ec7594911a9d584d577bc8e8b9bb546018667d820a67685df49201a11ae9b',
+        'does-not-matter',
+        'managed'
+      );
+
+      expect(utilsModule.deriveSponsorWallet).toHaveBeenCalledTimes(1);
+      expect(sponsorWallet.privateKey).toBe('0x1a193892271d2a8c1e39b9d78281a9e7f8c080965dc3ed744eac7746c47b700e');
+    });
   });
 
-  it('derives the sponsor wallet for a dAPI if it does not exist', () => {
-    const dapiName = utilsModule.encodeDapiName('ETH/USD');
-    jest.spyOn(stateModule, 'getState').mockReturnValue(
-      allowPartial<stateModule.State>({
-        derivedSponsorWallets: {},
-      })
-    );
-    jest.spyOn(stateModule, 'updateState').mockImplementation();
-    jest.spyOn(utilsModule, 'deriveSponsorWallet');
+  describe('self-funded feeds', () => {
+    it('derives the sponsor wallet for a dAPI if it does not exist', () => {
+      const dapiName = utilsModule.encodeDapiName('ETH/USD');
+      const updateParameters =
+        '0x0000000000000000000000000000000000000000000000000000000002faf0800000000000000000000000000000000000000000000000000000000002faf0800000000000000000000000000000000000000000000000000000000000000064';
+      jest.spyOn(stateModule, 'getState').mockReturnValue(
+        allowPartial<stateModule.State>({
+          derivedSponsorWallets: {},
+        })
+      );
+      jest.spyOn(stateModule, 'updateState').mockImplementation();
+      jest.spyOn(utilsModule, 'deriveSponsorWallet');
 
-    const sponsorWallet = submitTransactionsModule.getDerivedSponsorWallet(
-      'diamond result history offer forest diagram crop armed stumble orchard stage glance',
-      dapiName,
-      'does-not-matter',
-      'managed'
-    );
+      const sponsorWallet = submitTransactionsModule.getDerivedSponsorWallet(
+        'diamond result history offer forest diagram crop armed stumble orchard stage glance',
+        dapiName,
+        updateParameters,
+        'self-funded'
+      );
 
-    expect(utilsModule.deriveSponsorWallet).toHaveBeenCalledTimes(1);
-    expect(sponsorWallet.privateKey).toBe('0xd4cc2592775d876d6af59163bb7894272d84f538439e3c53af3bebdc0668b49d');
-  });
-
-  it('derives the sponsor wallet for a data feed ID if it does not exist', () => {
-    jest.spyOn(stateModule, 'getState').mockReturnValue(
-      allowPartial<stateModule.State>({
-        derivedSponsorWallets: {},
-      })
-    );
-    jest.spyOn(stateModule, 'updateState').mockImplementation();
-    jest.spyOn(utilsModule, 'deriveSponsorWallet');
-
-    const sponsorWallet = submitTransactionsModule.getDerivedSponsorWallet(
-      'diamond result history offer forest diagram crop armed stumble orchard stage glance',
-      '0x173ec7594911a9d584d577bc8e8b9bb546018667d820a67685df49201a11ae9b',
-      'does-not-matter',
-      'managed'
-    );
-    // TODO: Write a similar test for self-funded
-
-    expect(utilsModule.deriveSponsorWallet).toHaveBeenCalledTimes(1);
-    expect(sponsorWallet.privateKey).toBe('0x1a193892271d2a8c1e39b9d78281a9e7f8c080965dc3ed744eac7746c47b700e');
+      expect(utilsModule.deriveSponsorWallet).toHaveBeenCalledTimes(1);
+      expect(sponsorWallet.privateKey).toBe('0x858cd2fbfc60014023911f94190ee4f4bb2d5acf8910a4c0c47596db5717ce5a');
+    });
   });
 });
 

--- a/src/update-feeds-loops/submit-transactions.test.ts
+++ b/src/update-feeds-loops/submit-transactions.test.ts
@@ -247,7 +247,7 @@ describe(submitTransactionsModule.getDerivedSponsorWallet.name, () => {
       'some-mnemonic',
       dapiName,
       'does-not-matter',
-      'managed-dapis'
+      'managed'
     );
 
     expect(utilsModule.deriveSponsorWallet).toHaveBeenCalledTimes(0);
@@ -268,7 +268,7 @@ describe(submitTransactionsModule.getDerivedSponsorWallet.name, () => {
       'diamond result history offer forest diagram crop armed stumble orchard stage glance',
       dapiName,
       'does-not-matter',
-      'managed-dapis'
+      'managed'
     );
 
     expect(utilsModule.deriveSponsorWallet).toHaveBeenCalledTimes(1);
@@ -288,7 +288,7 @@ describe(submitTransactionsModule.getDerivedSponsorWallet.name, () => {
       'diamond result history offer forest diagram crop armed stumble orchard stage glance',
       '0x173ec7594911a9d584d577bc8e8b9bb546018667d820a67685df49201a11ae9b',
       'does-not-matter',
-      'managed-dapis'
+      'managed'
     );
     // TODO: Write a similar test for self-funded
 

--- a/src/update-feeds-loops/submit-transactions.test.ts
+++ b/src/update-feeds-loops/submit-transactions.test.ts
@@ -243,7 +243,12 @@ describe(submitTransactionsModule.getDerivedSponsorWallet.name, () => {
     );
     jest.spyOn(utilsModule, 'deriveSponsorWallet');
 
-    const sponsorWallet = submitTransactionsModule.getDerivedSponsorWallet('some-mnemonic', dapiName);
+    const sponsorWallet = submitTransactionsModule.getDerivedSponsorWallet(
+      'some-mnemonic',
+      dapiName,
+      'does-not-matter',
+      'managed-dapis'
+    );
 
     expect(utilsModule.deriveSponsorWallet).toHaveBeenCalledTimes(0);
     expect(sponsorWallet.privateKey).toBe('0x034e238bdc2622122e7b2191ee5be5df38597b6f58e45b25c6d32cae3110ebfa');
@@ -261,7 +266,9 @@ describe(submitTransactionsModule.getDerivedSponsorWallet.name, () => {
 
     const sponsorWallet = submitTransactionsModule.getDerivedSponsorWallet(
       'diamond result history offer forest diagram crop armed stumble orchard stage glance',
-      dapiName
+      dapiName,
+      'does-not-matter',
+      'managed-dapis'
     );
 
     expect(utilsModule.deriveSponsorWallet).toHaveBeenCalledTimes(1);
@@ -279,8 +286,11 @@ describe(submitTransactionsModule.getDerivedSponsorWallet.name, () => {
 
     const sponsorWallet = submitTransactionsModule.getDerivedSponsorWallet(
       'diamond result history offer forest diagram crop armed stumble orchard stage glance',
-      '0x173ec7594911a9d584d577bc8e8b9bb546018667d820a67685df49201a11ae9b'
+      '0x173ec7594911a9d584d577bc8e8b9bb546018667d820a67685df49201a11ae9b',
+      'does-not-matter',
+      'managed-dapis'
     );
+    // TODO: Write a similar test for self-funded
 
     expect(utilsModule.deriveSponsorWallet).toHaveBeenCalledTimes(1);
     expect(sponsorWallet.privateKey).toBe('0x1a193892271d2a8c1e39b9d78281a9e7f8c080965dc3ed744eac7746c47b700e');

--- a/src/update-feeds-loops/update-feeds-loops.test.ts
+++ b/src/update-feeds-loops/update-feeds-loops.test.ts
@@ -172,7 +172,7 @@ describe(updateFeedsLoopsModule.runUpdateFeeds.name, () => {
     const firstDataFeed = generateActiveDataFeedResponse();
     const thirdDataFeed = generateActiveDataFeedResponse();
     const decodedFirstDataFeed = {
-      ...omit(firstDataFeed, ['dataFeedDetails', 'updateParameters', 'beaconValues', 'beaconTimestamps']),
+      ...omit(firstDataFeed, ['dataFeedDetails', 'beaconValues', 'beaconTimestamps']),
       decodedUpdateParameters: contractsModule.decodeUpdateParameters(firstDataFeed.updateParameters),
       beaconsWithData: contractsModule.createBeaconsWithData(
         contractsModule.decodeDataFeedDetails(firstDataFeed.dataFeedDetails)!,
@@ -181,7 +181,7 @@ describe(updateFeedsLoopsModule.runUpdateFeeds.name, () => {
       ),
     };
     const decodedThirdDataFeed = {
-      ...omit(thirdDataFeed, ['dataFeedDetails', 'updateParameters', 'beaconValues', 'beaconTimestamps']),
+      ...omit(thirdDataFeed, ['dataFeedDetails', 'beaconValues', 'beaconTimestamps']),
       decodedUpdateParameters: contractsModule.decodeUpdateParameters(thirdDataFeed.updateParameters),
       beaconsWithData: contractsModule.createBeaconsWithData(
         contractsModule.decodeDataFeedDetails(thirdDataFeed.dataFeedDetails)!,

--- a/src/update-feeds-loops/update-feeds-loops.test.ts
+++ b/src/update-feeds-loops/update-feeds-loops.test.ts
@@ -359,7 +359,7 @@ describe(updateFeedsLoopsModule.processBatch.name, () => {
     const beacons = contractsModule.decodeDataFeedDetails(dataFeed.dataFeedDetails)!;
     const decodedUpdateParameters = contractsModule.decodeUpdateParameters(dataFeed.updateParameters);
     const activeDataFeed = {
-      ...omit(dataFeed, ['dataFeedDetails', 'updateParameters', 'beaconValues', 'beaconTimestamps']),
+      ...omit(dataFeed, ['dataFeedDetails', 'beaconValues', 'beaconTimestamps']),
       decodedUpdateParameters,
       beaconsWithData: contractsModule.createBeaconsWithData(beacons, dataFeed.beaconValues, dataFeed.beaconTimestamps),
       decodedDapiName: utilsModule.decodeDapiName(dataFeed.dapiName),

--- a/src/update-feeds-loops/update-feeds-loops.ts
+++ b/src/update-feeds-loops/update-feeds-loops.ts
@@ -8,7 +8,7 @@ import { logger } from '../logger';
 import { getState, updateState } from '../state';
 import type { AirseekerRegistry } from '../typechain-types';
 import type { ChainId, ProviderName } from '../types';
-import { deriveSponsorWallet, sleep } from '../utils';
+import { sleep } from '../utils';
 
 import {
   decodeActiveDataFeedCountResponse,
@@ -21,7 +21,7 @@ import {
   decodeGetChainIdResponse,
 } from './contracts';
 import { getUpdatableFeeds } from './get-updatable-feeds';
-import { hasSponsorPendingTransaction, submitTransactions } from './submit-transactions';
+import { getDerivedSponsorWallet, hasSponsorPendingTransaction, submitTransactions } from './submit-transactions';
 
 export const startUpdateFeedsLoops = async () => {
   const state = getState();
@@ -297,7 +297,7 @@ export const processBatch = async (
       continue;
     }
 
-    const sponsorWalletAddress = deriveSponsorWallet(
+    const sponsorWalletAddress = getDerivedSponsorWallet(
       sponsorWalletMnemonic,
       dapiName ?? dataFeedId,
       updateParameters,

--- a/src/update-feeds-loops/update-feeds-loops.ts
+++ b/src/update-feeds-loops/update-feeds-loops.ts
@@ -262,7 +262,7 @@ export const processBatch = async (
     blockNumber,
   });
   const {
-    config: { sponsorWalletMnemonic, chains, deviationThresholdCoefficient },
+    config: { sponsorWalletMnemonic, chains, deviationThresholdCoefficient, walletDerivationScheme },
   } = getState();
   const { contracts } = chains[chainId]!;
 
@@ -285,7 +285,7 @@ export const processBatch = async (
 
   // Clear last update timestamps for feeds that don't need an update
   for (const feed of batch) {
-    const { dapiName, dataFeedId, decodedDapiName } = feed;
+    const { dapiName, dataFeedId, decodedDapiName, updateParameters } = feed;
 
     // Skip if the data feed is updatable
     if (
@@ -297,7 +297,12 @@ export const processBatch = async (
       continue;
     }
 
-    const sponsorWalletAddress = deriveSponsorWallet(sponsorWalletMnemonic, dapiName ?? dataFeedId).address;
+    const sponsorWalletAddress = deriveSponsorWallet(
+      sponsorWalletMnemonic,
+      dapiName ?? dataFeedId,
+      updateParameters,
+      walletDerivationScheme
+    ).address;
     const timestampNeedsClearing = hasSponsorPendingTransaction(chainId, providerName, sponsorWalletAddress);
     if (timestampNeedsClearing) {
       // NOTE: A data feed may stop needing an update for two reasons:

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,26 +1,43 @@
 import { ethers } from 'hardhat';
 
-import { deriveSponsorWallet, deriveWalletPathFromSponsorAddress, encodeDapiName } from './utils';
+import {
+  deriveSponsorAddressHashForManagedFeed,
+  deriveSponsorWalletFromSponsorAddressHash,
+  deriveWalletPathFromSponsorAddress,
+  encodeDapiName,
+} from './utils';
 
-describe(deriveSponsorWallet.name, () => {
-  it('derives different wallets for dAPIs with same prefix', () => {
-    const dapiName = encodeDapiName('Ethereum - Avalanche');
-    const otherDapiName = encodeDapiName('Ethereum - Avalanche (DEX)');
-    const sponsorWalletMnemonic = 'diamond result history offer forest diagram crop armed stumble orchard stage glance';
+// TODO: Tests for other functions
 
-    const sponsorWallet = deriveSponsorWallet(sponsorWalletMnemonic, dapiName);
-    const otherSponsorWallet = deriveSponsorWallet(sponsorWalletMnemonic, otherDapiName);
+describe(deriveSponsorWalletFromSponsorAddressHash.name, () => {
+  describe(deriveSponsorAddressHashForManagedFeed.name, () => {
+    it('derives different wallets for dAPIs with same prefix', () => {
+      const dapiName = encodeDapiName('Ethereum - Avalanche');
+      const otherDapiName = encodeDapiName('Ethereum - Avalanche (DEX)');
+      const sponsorWalletMnemonic =
+        'diamond result history offer forest diagram crop armed stumble orchard stage glance';
 
-    expect(sponsorWallet.address).not.toBe(otherSponsorWallet.address);
-  });
+      const sponsorAddressHash = deriveSponsorAddressHashForManagedFeed(dapiName);
+      const sponsorWallet = deriveSponsorWalletFromSponsorAddressHash(sponsorWalletMnemonic, sponsorAddressHash);
+      const otherSponsorAddressHash = deriveSponsorAddressHashForManagedFeed(otherDapiName);
+      const otherSponsorWallet = deriveSponsorWalletFromSponsorAddressHash(
+        sponsorWalletMnemonic,
+        otherSponsorAddressHash
+      );
 
-  it('works even with data feed ID', () => {
-    const dataFeedId = '0x917ecd1b870ef5fcbd53088046d0987493593d761e2516ec6acc455848976f36';
-    const sponsorWalletMnemonic = 'diamond result history offer forest diagram crop armed stumble orchard stage glance';
+      expect(sponsorWallet.address).not.toBe(otherSponsorWallet.address);
+    });
 
-    const sponsorWallet = deriveSponsorWallet(sponsorWalletMnemonic, dataFeedId);
+    it('works even with data feed ID', () => {
+      const dataFeedId = '0x917ecd1b870ef5fcbd53088046d0987493593d761e2516ec6acc455848976f36';
+      const sponsorWalletMnemonic =
+        'diamond result history offer forest diagram crop armed stumble orchard stage glance';
 
-    expect(sponsorWallet.address).toBe('0x6fD46d2D7AB4574Be0185618944106fdaF20DB7D');
+      const sponsorAddressHash = deriveSponsorAddressHashForManagedFeed(dataFeedId);
+      const sponsorWallet = deriveSponsorWalletFromSponsorAddressHash(sponsorWalletMnemonic, sponsorAddressHash);
+
+      expect(sponsorWallet.address).toBe('0x6fD46d2D7AB4574Be0185618944106fdaF20DB7D');
+    });
   });
 });
 

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -2,12 +2,12 @@ import { ethers } from 'hardhat';
 
 import {
   deriveSponsorAddressHashForManagedFeed,
+  deriveSponsorAddressHashForSelfFundedFeed,
+  deriveSponsorWallet,
   deriveSponsorWalletFromSponsorAddressHash,
   deriveWalletPathFromSponsorAddress,
   encodeDapiName,
 } from './utils';
-
-// TODO: Tests for other functions
 
 describe(deriveSponsorWalletFromSponsorAddressHash.name, () => {
   describe(deriveSponsorAddressHashForManagedFeed.name, () => {
@@ -28,7 +28,7 @@ describe(deriveSponsorWalletFromSponsorAddressHash.name, () => {
       expect(sponsorWallet.address).not.toBe(otherSponsorWallet.address);
     });
 
-    it('works even with data feed ID', () => {
+    it('works with data feed ID', () => {
       const dataFeedId = '0x917ecd1b870ef5fcbd53088046d0987493593d761e2516ec6acc455848976f36';
       const sponsorWalletMnemonic =
         'diamond result history offer forest diagram crop armed stumble orchard stage glance';
@@ -36,8 +36,45 @@ describe(deriveSponsorWalletFromSponsorAddressHash.name, () => {
       const sponsorAddressHash = deriveSponsorAddressHashForManagedFeed(dataFeedId);
       const sponsorWallet = deriveSponsorWalletFromSponsorAddressHash(sponsorWalletMnemonic, sponsorAddressHash);
 
-      expect(sponsorWallet.address).toBe('0x6fD46d2D7AB4574Be0185618944106fdaF20DB7D');
+      expect(sponsorWallet.address).toBe('0x6fD46d2D7AB4574Be0185618944106fdaF20DB7D'); // Note, that the address is different if the sponsor address hash is derived using the "self-funded" scheme.
     });
+  });
+
+  describe(deriveSponsorAddressHashForSelfFundedFeed.name, () => {
+    it('derives a wallet for a self-funded feed', () => {
+      const dataFeedId = '0x917ecd1b870ef5fcbd53088046d0987493593d761e2516ec6acc455848976f36';
+      const updateParameters =
+        '0x0000000000000000000000000000000000000000000000000000000002faf0800000000000000000000000000000000000000000000000000000000002faf0800000000000000000000000000000000000000000000000000000000000000064';
+      const sponsorWalletMnemonic =
+        'diamond result history offer forest diagram crop armed stumble orchard stage glance';
+
+      const sponsorAddressHash = deriveSponsorAddressHashForSelfFundedFeed(dataFeedId, updateParameters);
+      const sponsorWallet = deriveSponsorWalletFromSponsorAddressHash(sponsorWalletMnemonic, sponsorAddressHash);
+
+      expect(sponsorWallet.address).toBe('0x08E47E2dF1440492289da760B58d036b3abb1A43'); // Note, that the address is different if the sponsor address hash is derived using the "managed" scheme.
+    });
+  });
+});
+
+describe(deriveSponsorWallet.name, () => {
+  it('derives a wallet for a managed feed', () => {
+    const dapiName = encodeDapiName('Ethereum - Avalanche');
+    const sponsorWalletMnemonic = 'diamond result history offer forest diagram crop armed stumble orchard stage glance';
+
+    const sponsorWallet = deriveSponsorWallet(sponsorWalletMnemonic, dapiName, 'does-not-matter', 'managed');
+
+    expect(sponsorWallet.address).toBe('0xDF5Eb6273BdB4608e70Bb0ABCA0571B45Cb60a22'); // Note, that the address is different if the sponsor address hash is derived using the "self-funded" scheme.
+  });
+
+  it('derives a wallet for a self-funded feed', () => {
+    const dapiName = encodeDapiName('Ethereum - Avalanche');
+    const updateParameters =
+      '0x0000000000000000000000000000000000000000000000000000000002faf0800000000000000000000000000000000000000000000000000000000002faf0800000000000000000000000000000000000000000000000000000000000000064';
+    const sponsorWalletMnemonic = 'diamond result history offer forest diagram crop armed stumble orchard stage glance';
+
+    const sponsorWallet = deriveSponsorWallet(sponsorWalletMnemonic, dapiName, updateParameters, 'self-funded');
+
+    expect(sponsorWallet.address).toBe('0x1e0cb43e47bf4335d21812C2d652fC83F2CB64Bb'); // Note, that the address is different if the sponsor address hash is derived using the "managed" scheme.
   });
 });
 

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -61,7 +61,7 @@ describe(deriveSponsorWallet.name, () => {
     const dapiName = encodeDapiName('Ethereum - Avalanche');
     const sponsorWalletMnemonic = 'diamond result history offer forest diagram crop armed stumble orchard stage glance';
 
-    const sponsorWallet = deriveSponsorWallet(sponsorWalletMnemonic, dapiName, 'does-not-matter', 'managed');
+    const sponsorWallet = deriveSponsorWallet(sponsorWalletMnemonic, dapiName, 'does-not-matter', { type: 'managed' });
 
     expect(sponsorWallet.address).toBe('0xDF5Eb6273BdB4608e70Bb0ABCA0571B45Cb60a22'); // Note, that the address is different if the sponsor address hash is derived using the "self-funded" scheme.
   });
@@ -72,7 +72,9 @@ describe(deriveSponsorWallet.name, () => {
       '0x0000000000000000000000000000000000000000000000000000000002faf0800000000000000000000000000000000000000000000000000000000002faf0800000000000000000000000000000000000000000000000000000000000000064';
     const sponsorWalletMnemonic = 'diamond result history offer forest diagram crop armed stumble orchard stage glance';
 
-    const sponsorWallet = deriveSponsorWallet(sponsorWalletMnemonic, dapiName, updateParameters, 'self-funded');
+    const sponsorWallet = deriveSponsorWallet(sponsorWalletMnemonic, dapiName, updateParameters, {
+      type: 'self-funded',
+    });
 
     expect(sponsorWallet.address).toBe('0x1e0cb43e47bf4335d21812C2d652fC83F2CB64Bb'); // Note, that the address is different if the sponsor address hash is derived using the "managed" scheme.
   });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -59,9 +59,11 @@ export const deriveSponsorWallet = (
   updateParameters: string,
   walletDerivationScheme: WalletDerivationScheme
 ) => {
-  // Derive the hash of the data feed using which the sponsor wallet is derived. For self-funded feeds it's more
-  // suitable to derive the hash also from update parameters. This does not apply to mananaged feeds which want to be
-  // funded by the same wallet independently of the update parameters.
+  // Derive the sponsor address hash, whose first 20 bytes are interpreted as the sponsor address. This address is used
+  // to derive the sponsor wallet.
+  //
+  // For self-funded feeds it's more suitable to derive the hash also from update parameters. This does not apply to
+  // mananaged feeds which want to be funded by the same wallet independently of the update parameters.
   const sponsorAddressHash =
     walletDerivationScheme === 'self-funded'
       ? deriveSponsorAddressHashForSelfFundedFeed(dapiNameOrDataFeedId, updateParameters)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -65,7 +65,7 @@ export const deriveSponsorWallet = (
   // For self-funded feeds it's more suitable to derive the hash also from update parameters. This does not apply to
   // mananaged feeds which want to be funded by the same wallet independently of the update parameters.
   const sponsorAddressHash =
-    walletDerivationScheme === 'self-funded'
+    walletDerivationScheme.type === 'self-funded'
       ? deriveSponsorAddressHashForSelfFundedFeed(dapiNameOrDataFeedId, updateParameters)
       : deriveSponsorAddressHashForManagedFeed(dapiNameOrDataFeedId);
 

--- a/test/e2e/update-feeds.feature.ts
+++ b/test/e2e/update-feeds.feature.ts
@@ -62,13 +62,14 @@ it('updates blockchain data', async () => {
   const beacons = decodeDataFeedDetails(dataFeedDetails)!;
   const activeBtcDataFeed = {
     dapiName,
+    decodedDapiName: decodeDapiName(dapiName),
+    updateParameters,
+    decodedUpdateParameters: decodeUpdateParameters(updateParameters),
     dataFeedId,
     dataFeedValue,
     dataFeedTimestamp,
     signedApiUrls,
-    decodedUpdateParameters: decodeUpdateParameters(updateParameters),
     beaconsWithData: createBeaconsWithData(beacons, beaconValues, beaconTimestamps),
-    decodedDapiName: decodeDapiName(dapiName),
   };
 
   const currentBlock = await provider.getBlock('latest');

--- a/test/fixtures/mock-config.ts
+++ b/test/fixtures/mock-config.ts
@@ -26,7 +26,7 @@ export const generateTestConfig = (): Config => ({
   signedDataFetchInterval: 10,
   deviationThresholdCoefficient: 1,
   signedApiUrls: [],
-  walletDerivationScheme: 'managed-dapis',
+  walletDerivationScheme: 'managed',
 });
 
 export const initializeState = (config: Config = generateTestConfig()) => setInitialState(config);

--- a/test/fixtures/mock-config.ts
+++ b/test/fixtures/mock-config.ts
@@ -26,7 +26,7 @@ export const generateTestConfig = (): Config => ({
   signedDataFetchInterval: 10,
   deviationThresholdCoefficient: 1,
   signedApiUrls: [],
-  walletDerivationScheme: 'managed',
+  walletDerivationScheme: { type: 'managed' },
 });
 
 export const initializeState = (config: Config = generateTestConfig()) => setInitialState(config);

--- a/test/fixtures/mock-config.ts
+++ b/test/fixtures/mock-config.ts
@@ -26,6 +26,7 @@ export const generateTestConfig = (): Config => ({
   signedDataFetchInterval: 10,
   deviationThresholdCoefficient: 1,
   signedApiUrls: [],
+  walletDerivationScheme: 'managed-dapis',
 });
 
 export const initializeState = (config: Config = generateTestConfig()) => setInitialState(config);

--- a/test/setup/contract.ts
+++ b/test/setup/contract.ts
@@ -8,7 +8,12 @@ import {
   AirseekerRegistry__factory as AirseekerRegistryFactory,
   type Api3ServerV1,
 } from '../../src/typechain-types';
-import { deriveBeaconId, deriveSponsorWallet, encodeDapiName } from '../../src/utils';
+import {
+  deriveBeaconId,
+  deriveSponsorAddressHashForManagedFeed,
+  deriveSponsorWalletFromSponsorAddressHash,
+  encodeDapiName,
+} from '../../src/utils';
 import { generateTestConfig } from '../fixtures/mock-config';
 import { signData } from '../utils';
 
@@ -256,7 +261,11 @@ export const deployAndUpdate = async () => {
     await airseekerRegistry.connect(deployerAndManager).setDapiNameToBeActivated(dapiName);
 
     // Initialize sponsor wallets
-    const sponsorWallet = deriveSponsorWallet(airseekerWallet.mnemonic!.phrase, dapiName);
+    const sponsorAddressHash = deriveSponsorAddressHashForManagedFeed(dapiName);
+    const sponsorWallet = deriveSponsorWalletFromSponsorAddressHash(
+      airseekerWallet.mnemonic!.phrase,
+      sponsorAddressHash
+    );
     await walletFunder!.sendTransaction({
       to: sponsorWallet.address,
       value: ethers.parseEther('1'),


### PR DESCRIPTION
Closes https://github.com/api3dao/airseeker-v2/issues/179

## Rationale

We have not discussed the details (mostly naming) so I went ahead with the following:
1. Added `walletDerivationScheme` in the root of the `airseeker.json` config.
2. The supported values are `self-funded` and `managed`.
See the [README.md changes](https://github.com/api3dao/airseeker-v2/compare/read-feeds-values-from-chain...self-funded-wallet-derivation?expand=1#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) for details.

The wallet derivation changes are [here](https://github.com/api3dao/airseeker-v2/compare/read-feeds-values-from-chain...self-funded-wallet-derivation?expand=1#diff-39b2554fd18da165b59a6351b1aafff3714e2a80c1435f2de9706355b4d32351) and the self-funded sponsor derivation takes into account the update parameters as referenced [here](https://api3workspace.slack.com/archives/C05TQPT7PNJ/p1706601083254309?thread_ts=1706521432.528779&cid=C05TQPT7PNJ).

## TODO

- [x] Mention this change in the spec.