### PR TITLE
Setup NPM publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,14 +32,15 @@ To release a new version:
    uncommitted changes).
 2. `pnpm version [major|minor|patch]` - Choose the right version bump. This will bump the version, create a git tag and
    commit it.
-3. Build the docker image with tag `api3/airseeker:latest`. If running on Linux, use `pnpm run docker:build` otherwise
+3. `pnpm publish --access public` - Build the package and publish the new version to NPM.
+4. `git push --follow-tags` - Push the tagged commit upstream.
+5. Create a GitHub release for the specific tag.
+6. Build the docker image with tag `api3/airseeker:latest`. If running on Linux, use `pnpm run docker:build` otherwise
    use `pnpm run docker:build:amd64`.
-4. `docker tag api3/airseeker:latest api3/airseeker:<MAJOR.MINOR.PATCH>` - Tag the image with the version. Replace the
+7. `docker tag api3/airseeker:latest api3/airseeker:<MAJOR.MINOR.PATCH>` - Tag the image with the version. Replace the
    `<MAJOR.MINOR.PATCH>` with the version you just bumped (copy it from `package.json`).
-5. `docker push api3/airseeker:latest && docker push api3/airseeker:<MAJOR.MINOR.PATCH>` - Push the image upstream. Both
+8. `docker push api3/airseeker:latest && docker push api3/airseeker:<MAJOR.MINOR.PATCH>` - Push the image upstream. Both
    the latest and the versioned tag should be published.
-6. `git push --follow-tags` - Push the tagged commit upstream.
-7. Create a GitHub release for the specific tag.
 
 ## Configuration
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "airseeker-v2",
+  "name": "@api3/airseeker",
   "version": "2.2.0",
   "keywords": [],
   "license": "MIT",
@@ -9,8 +9,9 @@
   },
   "files": [
     "dist",
-    "*.js"
+    "src"
   ],
+  "main": "./dist/npm-exports.js",
   "scripts": {
     "build": "tsc --project tsconfig.build.json",
     "clean": "rm -rf coverage dist artifacts cache",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "docker:run": "docker run -it --init --volume $(pwd)/config:/app/config --network host --env-file .env --rm api3/airseeker:latest",
     "eslint:check": "eslint --report-unused-disable-directives --cache --ext js,ts . --max-warnings 0",
     "eslint:fix": "pnpm run eslint:check --fix",
+    "prepublishOnly": "pnpm i && pnpm run clean && pnpm run build",
     "prettier:check": "prettier --check \"./**/*.{js,ts,md,json,html}\"",
     "prettier:fix": "prettier --write \"./**/*.{js,ts,md,json,html}\"",
     "test:e2e": "jest --config=jest-e2e.config.js",

--- a/src/npm-exports.ts
+++ b/src/npm-exports.ts
@@ -1,0 +1,4 @@
+// NOTE: This file defines the NPM exports. Everything that should be available to import from the NPM package should be
+// exported here.
+export * from './utils';
+export * from './config/schema';


### PR DESCRIPTION
Closes https://github.com/api3dao/airseeker-v2/issues/176

## Rationale

Inspired by the publishing in https://github.com/api3dao/commons. I am using the old https://www.npmjs.com/package/@api3/airseeker NPM package name.


I tested this using Verdaccio locally. The following is exported:
```
{
  abs: [Getter],
  sleep: [Getter],
  deriveBeaconId: [Getter],
  encodeDapiName: [Getter],
  decodeDapiName: [Getter],
  deriveWalletPathFromSponsorAddress: [Getter],
  deriveSponsorAddressHashForManagedFeed: [Getter],
  deriveSponsorAddressHashForSelfFundedFeed: [Getter],
  deriveSponsorWalletFromSponsorAddressHash: [Getter],
  deriveSponsorWallet: [Getter],
  multiplyBigNumber: [Getter],
  decodeBeaconValue: [Getter],
  evmAddressSchema: [Getter],
  evmIdSchema: [Getter],
  providerSchema: [Getter],
  optionalContractsSchema: [Getter],
  gasSettingsSchema: [Getter],
  optionalChainSchema: [Getter],
  chainsSchema: [Getter],
  deviationThresholdCoefficientSchema: [Getter],
  walletDerivationTypeSchema: [Getter],
  walletDerivationSchemeSchema: [Getter],
  configSchema: [Getter]
}
```