### PR TITLE
Set NODE_ENV to production, use node user

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,23 +6,21 @@ WORKDIR /app
 # Install pnpm globally (needs root privileges).
 RUN npm install -g pnpm
 
-# Create a new user and group to run the application with reduced privileges.
-RUN addgroup -S airseeker && \
-    adduser -h /app -s /bin/false -S -D -H -G airseeker airseeker && \
-    chown -R airseeker /app
-USER airseeker
+# "node" Docker images come with a built-in, least-privileged user called "node"
+USER node
 
 # Copy just the "pnpm-lock.yaml" file and use "pnpm fetch" to download all dependencies just from the lockfile. This
 # command is specifically designed to improve building a docker image because it only installs the dependencies if the
 # lockfile has changed (otherwise uses the cached value).
-COPY --chown=airseeker:airseeker pnpm-lock.yaml /app
+COPY --chown=node:node pnpm-lock.yaml /app
 RUN pnpm fetch
 # Copies all of the contents (without files listed in .dockerignore) of the monorepo into the image.
-COPY --chown=airseeker:airseeker . /app
+COPY --chown=node:node . /app
 # Ideally, we would use "--offline" option, but it seems pnpm has a bug. Fortunately, the instalation times are similar.
 # See: https://github.com/pnpm/pnpm/issues/6058 for details.
 RUN pnpm install --prefer-offline
 RUN pnpm run build
 
 # Start the Airseeker.
+ENV NODE_ENV=production
 ENTRYPOINT ["node", "dist/index.js"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,11 +18,9 @@ COPY . /app
 RUN pnpm install --prefer-offline
 RUN pnpm run build
 
-RUN chown -R node:node /app/config
-
+RUN chown --recursive node:node /app
 # "node" Docker images come with a built-in, least-privileged user called "node"
 USER node
-
 # Start the Airseeker.
 ENV NODE_ENV=production
 ENTRYPOINT ["node", "dist/index.js"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,20 +6,22 @@ WORKDIR /app
 # Install pnpm globally (needs root privileges).
 RUN npm install -g pnpm
 
-# "node" Docker images come with a built-in, least-privileged user called "node"
-USER node
-
 # Copy just the "pnpm-lock.yaml" file and use "pnpm fetch" to download all dependencies just from the lockfile. This
 # command is specifically designed to improve building a docker image because it only installs the dependencies if the
 # lockfile has changed (otherwise uses the cached value).
-COPY --chown=node:node pnpm-lock.yaml /app
+COPY pnpm-lock.yaml /app
 RUN pnpm fetch
 # Copies all of the contents (without files listed in .dockerignore) of the monorepo into the image.
-COPY --chown=node:node . /app
+COPY . /app
 # Ideally, we would use "--offline" option, but it seems pnpm has a bug. Fortunately, the instalation times are similar.
 # See: https://github.com/pnpm/pnpm/issues/6058 for details.
 RUN pnpm install --prefer-offline
 RUN pnpm run build
+
+RUN chown -R node:node /app/config
+
+# "node" Docker images come with a built-in, least-privileged user called "node"
+USER node
 
 # Start the Airseeker.
 ENV NODE_ENV=production

--- a/local-test-configuration/airseeker/airseeker.example.json
+++ b/local-test-configuration/airseeker/airseeker.example.json
@@ -26,5 +26,5 @@
   "deviationThresholdCoefficient": 1,
   "signedDataFetchInterval": 10,
   "signedApiUrls": [],
-  "walletDerivationScheme": { "type:": "managed" }
+  "walletDerivationScheme": { "type": "managed" }
 }


### PR DESCRIPTION
Closes https://github.com/api3dao/airseeker-v2/issues/199