### PR TITLE
Fix ethers provider draining resources in case of failure

### DIFF
--- a/src/update-feeds-loops/update-feeds-loops.test.ts
+++ b/src/update-feeds-loops/update-feeds-loops.test.ts
@@ -140,6 +140,7 @@ describe(updateFeedsLoopsModule.startUpdateFeedsLoops.name, () => {
 describe(updateFeedsLoopsModule.runUpdateFeeds.name, () => {
   it('aborts when fetching first data feed batch fails', async () => {
     const airseekerRegistry = generateMockAirseekerRegistry();
+    jest.spyOn(contractsModule, 'createProvider').mockResolvedValue(123 as any as ethers.JsonRpcProvider);
     jest
       .spyOn(contractsModule, 'getAirseekerRegistry')
       .mockReturnValue(airseekerRegistry as unknown as AirseekerRegistry);
@@ -190,6 +191,7 @@ describe(updateFeedsLoopsModule.runUpdateFeeds.name, () => {
       ),
     };
     const airseekerRegistry = generateMockAirseekerRegistry();
+    jest.spyOn(contractsModule, 'createProvider').mockResolvedValue(123 as any as ethers.JsonRpcProvider);
     jest
       .spyOn(contractsModule, 'getAirseekerRegistry')
       .mockReturnValue(airseekerRegistry as unknown as AirseekerRegistry);
@@ -302,6 +304,7 @@ describe(updateFeedsLoopsModule.runUpdateFeeds.name, () => {
   it('catches unhandled error', async () => {
     const dataFeed = generateActiveDataFeedResponse();
     const airseekerRegistry = generateMockAirseekerRegistry();
+    jest.spyOn(contractsModule, 'createProvider').mockResolvedValue(123 as any as ethers.JsonRpcProvider);
     jest
       .spyOn(contractsModule, 'getAirseekerRegistry')
       .mockReturnValue(airseekerRegistry as unknown as AirseekerRegistry);

--- a/src/update-feeds-loops/update-feeds-loops.ts
+++ b/src/update-feeds-loops/update-feeds-loops.ts
@@ -1,6 +1,6 @@
 import type { AirseekerRegistry } from '@api3/contracts';
 import { go } from '@api3/promise-utils';
-import { ethers } from 'ethers';
+import type { ethers } from 'ethers';
 import { isError, range, set, size, uniq } from 'lodash';
 
 import type { Chain } from '../config/schema';
@@ -19,6 +19,7 @@ import {
   getApi3ServerV1,
   decodeGetBlockNumberResponse,
   decodeGetChainIdResponse,
+  createProvider,
 } from './contracts';
 import { getUpdatableFeeds } from './get-updatable-feeds';
 import { getDerivedSponsorWallet, hasSponsorPendingTransaction, submitTransactions } from './submit-transactions';
@@ -148,9 +149,11 @@ export const runUpdateFeeds = async (providerName: ProviderName, chain: Chain, c
       const dataFeedUpdateIntervalMs = dataFeedUpdateInterval * 1000;
 
       // Create a provider and connect it to the AirseekerRegistry contract.
-      const provider = new ethers.JsonRpcProvider(providers[providerName]!.url, undefined, {
-        staticNetwork: true,
-      });
+      const provider = await createProvider(providers[providerName]!.url);
+      if (!provider) {
+        logger.info('Failed to create provider. This is likely an RPC issue.');
+        return;
+      }
       const airseekerRegistry = getAirseekerRegistry(contracts.AirseekerRegistry, provider);
 
       logger.debug(`Fetching first batch of data feeds batches.`);


### PR DESCRIPTION
Closes https://github.com/api3dao/airseeker-v2/issues/210

## Rationale

I made a function which creates the provider in safe way and tested it locally. I also [let ethers know of this incident](https://github.com/api3dao/airseeker-v2/issues/210#issuecomment-2009989322) as I think the implementation could change a little. 