### PR TITLE
Revisit INFO logs

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,9 +30,10 @@
   },
   "dependencies": {
     "@api3/airnode-protocol-v1": "^3.4.0",
+    "@api3/chains": "^4.13.1",
     "@api3/commons": "^0.8.0",
+    "@api3/contracts": "2.0.0-beta13",
     "@api3/promise-utils": "^0.4.0",
-    "@api3/contracts": "2.0.0-beta9",
     "axios": "^1.6.8",
     "dotenv": "^16.4.5",
     "ethers": "^6.11.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,12 +8,15 @@ dependencies:
   '@api3/airnode-protocol-v1':
     specifier: ^3.4.0
     version: 3.4.0
+  '@api3/chains':
+    specifier: ^4.13.1
+    version: 4.14.0(typescript@5.4.3)
   '@api3/commons':
     specifier: ^0.8.0
     version: 0.8.0(eslint@8.57.0)(jest@29.7.0)(typescript@5.4.3)
   '@api3/contracts':
-    specifier: 2.0.0-beta9
-    version: 2.0.0-beta9
+    specifier: 2.0.0-beta13
+    version: 2.0.0-beta13
   '@api3/promise-utils':
     specifier: ^0.4.0
     version: 0.4.0
@@ -110,6 +113,10 @@ packages:
     resolution: {integrity: sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==}
     engines: {node: '>=0.10.0'}
 
+  /@adraffy/ens-normalize@1.10.0:
+    resolution: {integrity: sha512-nA9XHtlAkYfJxY7bce8DcN7eKxWWCWkU+1GR9d+U6MbNpfwQp8TI7vqOsBsMcHoT4mBu2kypKoSKnghEzOOq5Q==}
+    dev: false
+
   /@adraffy/ens-normalize@1.10.1:
     resolution: {integrity: sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==}
 
@@ -134,6 +141,17 @@ packages:
     resolution: {integrity: sha512-jjnzJC82RUEJkDfrz/PAS2/JP8TyEsBKQhYBO4xzOIGrTCC+XscwpxTWVneuNpNsXmQFYjfjvXzEC4lgDqwvTQ==}
     dependencies:
       '@openzeppelin/contracts': 4.8.2
+    dev: false
+
+  /@api3/chains@4.14.0(typescript@5.4.3):
+    resolution: {integrity: sha512-zM37/EW6bsYVmu6wea+3+D7FlK60kI6LBYwCRxE85ISUUCT6gkclkFLksGN6vrw4ZTl9Xool2fbhALHiuYA7Uw==}
+    dependencies:
+      viem: 2.8.16(typescript@5.4.3)(zod@3.22.4)
+      zod: 3.22.4
+    transitivePeerDependencies:
+      - bufferutil
+      - typescript
+      - utf-8-validate
     dev: false
 
   /@api3/commons@0.8.0(eslint@8.57.0)(jest@29.7.0)(typescript@5.4.3):
@@ -179,9 +197,9 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@api3/contracts@2.0.0-beta9:
-    resolution: {integrity: sha512-wkYmh+dmSTyCwvfDF4RYrXNySJ6Y3lZRlDP8STlpyu9bpIVkCd7ZJ110UiUI2WQ4VuxqW2sUXoY5bsN47l0DfA==}
-    engines: {node: ^18.19.0}
+  /@api3/contracts@2.0.0-beta13:
+    resolution: {integrity: sha512-auANMlTc8Mui/mpsrcchEgACwqM52P3eD6LCO53Ugj+0/TluXi8N8uihBhSPf97rKKHpwlowopxk170tz8kVuw==}
+    engines: {node: ^20.11.1}
     dependencies:
       ethers: 6.11.1
     transitivePeerDependencies:
@@ -1622,7 +1640,6 @@ packages:
 
   /@scure/base@1.1.3:
     resolution: {integrity: sha512-/+SgoRjLq7Xlf0CWuLHq2LUZeL/w65kfzAPG5NH9pcmBhs+nunQTn4gvdwgMTIXnt9b2C/1SeL2XiysZEyIC9Q==}
-    dev: true
 
   /@scure/bip32@1.1.5:
     resolution: {integrity: sha512-XyNh1rB0SkEqd3tXcXMi+Xe1fvg+kUIcoRIEujP1Jgv7DqW2r9lg3Ah0NkFaCs9sTkQAQA8kw7xiRXzENi9Rtw==}
@@ -1640,6 +1657,14 @@ packages:
       '@scure/base': 1.1.3
     dev: true
 
+  /@scure/bip32@1.3.2:
+    resolution: {integrity: sha512-N1ZhksgwD3OBlwTv3R6KFEcPojl/W4ElJOeCZdi+vuI5QmTFwLq3OFf2zd2ROpKvxFdgZ6hUpb0dx9bVNEwYCA==}
+    dependencies:
+      '@noble/curves': 1.2.0
+      '@noble/hashes': 1.3.2
+      '@scure/base': 1.1.3
+    dev: false
+
   /@scure/bip39@1.1.1:
     resolution: {integrity: sha512-t+wDck2rVkh65Hmv280fYdVdY25J9YeEUIgn2LG1WM6gxFkGzcksoDiUkWVpVp3Oex9xGC68JU2dSbUfwZ2jPg==}
     dependencies:
@@ -1652,7 +1677,6 @@ packages:
     dependencies:
       '@noble/hashes': 1.3.2
       '@scure/base': 1.1.3
-    dev: true
 
   /@sentry/core@5.30.0:
     resolution: {integrity: sha512-TmfrII8w1PQZSZgPpUESqjB+jC6MvZJZdLtE/0hZ+SrnKhW3x5WlYLvTXZpcWePYBku7rl2wn1RZu6uT0qCTeg==}
@@ -2292,6 +2316,21 @@ packages:
   /abbrev@1.1.1:
     resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
     dev: true
+
+  /abitype@1.0.0(typescript@5.4.3)(zod@3.22.4):
+    resolution: {integrity: sha512-NMeMah//6bJ56H5XRj8QCV4AwuW6hB6zqz2LnhhLdcWVQOsXki6/Pn3APeqxCma62nXIcmZWdu1DlHWS74umVQ==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+      zod: ^3 >=3.22.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+      zod:
+        optional: true
+    dependencies:
+      typescript: 5.4.3
+      zod: 3.22.4
+    dev: false
 
   /acorn-jsx@5.3.2(acorn@8.10.0):
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -5193,6 +5232,14 @@ packages:
   /isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  /isows@1.0.3(ws@8.13.0):
+    resolution: {integrity: sha512-2cKei4vlmg2cxEjm3wVSqn8pcoRF/LX/wpifuuNquFO4SQmPwarClT+SUCA2lt+l581tTeZIPIZuIDo2jWN1fg==}
+    peerDependencies:
+      ws: '*'
+    dependencies:
+      ws: 8.13.0
+    dev: false
+
   /istanbul-lib-coverage@3.2.0:
     resolution: {integrity: sha512-eOeJ5BHCmHYvQK7xt9GkdHuzuCGS1Y6g9Gvnx3Ym33fz/HpLRYxiS0wHNr+m/MBC8B647Xt608vCDEvhl9c6Mw==}
     engines: {node: '>=8'}
@@ -7702,6 +7749,29 @@ packages:
       spdx-expression-parse: 3.0.1
     dev: false
 
+  /viem@2.8.16(typescript@5.4.3)(zod@3.22.4):
+    resolution: {integrity: sha512-J8tu1aP7TfI2HT/IEmyJ+n+WInrA/cuMuJtfgvYhYgHBobxhYGc2SojHm5lZBWcWgErN1Ld7VcKUwTmPh4ToQA==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@adraffy/ens-normalize': 1.10.0
+      '@noble/curves': 1.2.0
+      '@noble/hashes': 1.3.2
+      '@scure/bip32': 1.3.2
+      '@scure/bip39': 1.2.1
+      abitype: 1.0.0(typescript@5.4.3)(zod@3.22.4)
+      isows: 1.0.3(ws@8.13.0)
+      typescript: 5.4.3
+      ws: 8.13.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - zod
+    dev: false
+
   /walker@1.0.8:
     resolution: {integrity: sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==}
     dependencies:
@@ -7894,6 +7964,19 @@ packages:
       utf-8-validate:
         optional: true
     dev: true
+
+  /ws@8.13.0:
+    resolution: {integrity: sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+    dev: false
 
   /ws@8.5.0:
     resolution: {integrity: sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==}

--- a/src/data-fetcher-loop/data-fetcher-loop.ts
+++ b/src/data-fetcher-loop/data-fetcher-loop.ts
@@ -67,18 +67,17 @@ export const callSignedApi = async (url: string, timeout: number): Promise<Signe
 
 export const runDataFetcher = async () => {
   return logger.runWithContext({ dataFetcherCoordinatorId: Date.now().toString() }, async () => {
-    logger.debug('Running data fetcher.');
+    logger.info('Running data fetcher.');
+
     const state = getState();
     const {
       config: { signedDataFetchInterval },
       signedApiUrls,
     } = state;
-
     const signedDataFetchIntervalMs = signedDataFetchInterval * 1000;
 
     // Better to log the non-decomposed object to see which URL comes from which chain-provider group.
     logger.debug('Fetching data from signed APIs.', { signedApiUrls });
-
     const urls = uniq(
       Object.values(signedApiUrls)
         .map((urlsPerProvider) => Object.values(urlsPerProvider))

--- a/src/data-fetcher-loop/signed-data-state.ts
+++ b/src/data-fetcher-loop/signed-data-state.ts
@@ -59,7 +59,7 @@ export const verifySignedDataIntegrity = (signedData: SignedData) => {
 };
 
 export const saveSignedData = (signedData: SignedData) => {
-  const { airnode, templateId, signature, timestamp, encodedValue } = signedData;
+  const { airnode, templateId, timestamp } = signedData;
 
   if (!verifySignedDataIntegrity(signedData)) {
     return;
@@ -76,17 +76,11 @@ export const saveSignedData = (signedData: SignedData) => {
   }
 
   if (!isSignedDataFresh(signedData)) {
-    logger.debug('Skipping state update. The signed data value is older than 24 hours.');
+    // This should not happen under normal circumstances. Something must be off with the Signed API.
+    logger.warn('Skipping state update. The signed data value is older than 24 hours.');
     return;
   }
 
-  logger.debug(`Storing signed data.`, {
-    airnode,
-    templateId,
-    timestamp,
-    signature,
-    encodedValue,
-  });
   updateState((draft) => {
     draft.signedDatas[dataFeedId] = signedData;
   });

--- a/src/deviation-check/deviation-check.ts
+++ b/src/deviation-check/deviation-check.ts
@@ -65,7 +65,7 @@ export const isDataFeedUpdatable = (
       return true;
     }
   } else {
-    logger.debug(`On-chain timestamp is older than the heartbeat interval.`);
+    logger.info(`On-chain timestamp is older than the heartbeat interval.`);
     return true;
   }
 

--- a/src/gas-price/gas-price.test.ts
+++ b/src/gas-price/gas-price.test.ts
@@ -144,6 +144,7 @@ describe(getRecommendedGasPrice.name, () => {
     jest.spyOn(Date, 'now').mockReturnValue(dateNowMock);
     jest.spyOn(provider, 'getFeeData').mockResolvedValueOnce({ gasPrice: ethers.parseUnits('10', 'gwei') } as any);
     jest.spyOn(logger, 'debug');
+    jest.spyOn(logger, 'info');
 
     const gasPrice = await getRecommendedGasPrice(chainId, providerName, provider, sponsorWalletAddress);
 
@@ -152,11 +153,13 @@ describe(getRecommendedGasPrice.name, () => {
       { price: ethers.parseUnits('10', 'gwei'), timestamp: timestampMock },
     ]);
 
-    expect(logger.debug).toHaveBeenCalledTimes(3);
+    expect(logger.debug).toHaveBeenCalledTimes(2);
     expect(logger.debug).toHaveBeenNthCalledWith(1, 'Fetching gas price and saving it to the state.');
     expect(logger.debug).toHaveBeenNthCalledWith(2, 'Purging old gas prices.');
-    expect(logger.debug).toHaveBeenNthCalledWith(
-      3,
+
+    expect(logger.info).toHaveBeenCalledTimes(1);
+    expect(logger.info).toHaveBeenNthCalledWith(
+      1,
       'No historical gas prices to compute the percentile. Using the provider recommended gas price.'
     );
   });

--- a/src/gas-price/gas-price.test.ts
+++ b/src/gas-price/gas-price.test.ts
@@ -144,7 +144,7 @@ describe(getRecommendedGasPrice.name, () => {
     jest.spyOn(Date, 'now').mockReturnValue(dateNowMock);
     jest.spyOn(provider, 'getFeeData').mockResolvedValueOnce({ gasPrice: ethers.parseUnits('10', 'gwei') } as any);
     jest.spyOn(logger, 'debug');
-    jest.spyOn(logger, 'info');
+    jest.spyOn(logger, 'warn');
 
     const gasPrice = await getRecommendedGasPrice(chainId, providerName, provider, sponsorWalletAddress);
 
@@ -157,8 +157,8 @@ describe(getRecommendedGasPrice.name, () => {
     expect(logger.debug).toHaveBeenNthCalledWith(1, 'Fetching gas price and saving it to the state.');
     expect(logger.debug).toHaveBeenNthCalledWith(2, 'Purging old gas prices.');
 
-    expect(logger.info).toHaveBeenCalledTimes(1);
-    expect(logger.info).toHaveBeenNthCalledWith(
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    expect(logger.warn).toHaveBeenNthCalledWith(
       1,
       'No historical gas prices to compute the percentile. Using the provider recommended gas price.'
     );

--- a/src/gas-price/gas-price.ts
+++ b/src/gas-price/gas-price.ts
@@ -186,7 +186,7 @@ export const getRecommendedGasPrice = async (
     gasPrices.map((gasPrice) => gasPrice.price)
   );
   if (!percentileGasPrice) {
-    logger.debug('No historical gas prices to compute the percentile. Using the provider recommended gas price.');
+    logger.info('No historical gas prices to compute the percentile. Using the provider recommended gas price.');
     return multiplyBigNumber(gasPrice, recommendedGasPriceMultiplier);
   }
 

--- a/src/gas-price/gas-price.ts
+++ b/src/gas-price/gas-price.ts
@@ -186,7 +186,7 @@ export const getRecommendedGasPrice = async (
     gasPrices.map((gasPrice) => gasPrice.price)
   );
   if (!percentileGasPrice) {
-    logger.info('No historical gas prices to compute the percentile. Using the provider recommended gas price.');
+    logger.warn('No historical gas prices to compute the percentile. Using the provider recommended gas price.');
     return multiplyBigNumber(gasPrice, recommendedGasPriceMultiplier);
   }
 

--- a/src/update-feeds-loops/get-updatable-feeds.test.ts
+++ b/src/update-feeds-loops/get-updatable-feeds.test.ts
@@ -137,7 +137,7 @@ describe(getUpdatableFeeds.name, () => {
     jest
       .spyOn(signedDataStateModule, 'getSignedData')
       .mockImplementation((dataFeedId: string) => mockSignedDataState[dataFeedId]!);
-    jest.spyOn(logger, 'debug');
+    jest.spyOn(logger, 'info');
 
     const batch = allowPartial<contractsModule.DecodedActiveDataFeedResponse[]>([
       {
@@ -159,7 +159,7 @@ describe(getUpdatableFeeds.name, () => {
 
     const checkFeedsResult = getUpdatableFeeds(batch, 1);
 
-    expect(logger.debug).toHaveBeenCalledWith(`On-chain timestamp is older than the heartbeat interval.`);
+    expect(logger.info).toHaveBeenCalledWith(`On-chain timestamp is older than the heartbeat interval.`);
     expect(checkFeedsResult).toStrictEqual([
       {
         updatableBeacons: [

--- a/src/update-feeds-loops/submit-transactions.test.ts
+++ b/src/update-feeds-loops/submit-transactions.test.ts
@@ -48,7 +48,7 @@ describe(submitTransactionsModule.estimateMulticallGasLimit.name, () => {
         ['0xBeaconId1Calldata', '0xBeaconId2Calldata', '0xBeaconSetCalldata'],
         undefined
       )
-    ).rejects.toStrictEqual(new Error('Unable to estimate gas limit'));
+    ).rejects.toStrictEqual(new Error('No fallback gas limit provided.'));
   });
 });
 

--- a/src/update-feeds-loops/submit-transactions.ts
+++ b/src/update-feeds-loops/submit-transactions.ts
@@ -167,7 +167,7 @@ export const estimateMulticallGasLimit = async (
     // Adding a extra 10% because multicall consumes less gas than tryMulticall
     return (goEstimateGas.data * BigInt(Math.round(1.1 * 100))) / 100n;
   }
-  logger.warn(`Unable to estimate gas for multicall using provider.`, goEstimateGas.error);
+  logger.warn(`Unable to estimate gas for multicall using provider.`, { errorMessage: goEstimateGas.error.message });
 
   if (!fallbackGasLimit) {
     throw new Error('Unable to estimate gas limit');

--- a/src/update-feeds-loops/submit-transactions.ts
+++ b/src/update-feeds-loops/submit-transactions.ts
@@ -170,7 +170,7 @@ export const estimateMulticallGasLimit = async (
   logger.warn(`Unable to estimate gas for multicall using provider.`, { errorMessage: goEstimateGas.error.message });
 
   if (!fallbackGasLimit) {
-    throw new Error('Unable to estimate gas limit');
+    throw new Error('No fallback gas limit provided.');
   }
 
   return BigInt(fallbackGasLimit);

--- a/src/update-feeds-loops/update-feeds-loops.ts
+++ b/src/update-feeds-loops/update-feeds-loops.ts
@@ -151,7 +151,7 @@ export const runUpdateFeeds = async (providerName: ProviderName, chain: Chain, c
       // Create a provider and connect it to the AirseekerRegistry contract.
       const provider = await createProvider(providers[providerName]!.url);
       if (!provider) {
-        logger.info('Failed to create provider. This is likely an RPC issue.');
+        logger.warn('Failed to create provider. This is likely an RPC issue.');
         return;
       }
       const airseekerRegistry = getAirseekerRegistry(contracts.AirseekerRegistry, provider);
@@ -239,7 +239,7 @@ export const runUpdateFeeds = async (providerName: ProviderName, chain: Chain, c
       const skippedBatchesCount = processedBatches.filter((batch) => !batch).length;
       const dataFeedUpdates = processedBatches.reduce((acc, batch) => acc + (batch ? batch.successCount : 0), 0);
       const dataFeedUpdateFailures = processedBatches.reduce((acc, batch) => acc + (batch ? batch.errorCount : 0), 0);
-      logger.debug(`Finished processing batches of active data feeds.`, {
+      logger.info(`Finished processing batches of active data feeds.`, {
         skippedBatchesCount,
         dataFeedUpdates,
         dataFeedUpdateFailures,

--- a/src/update-feeds-loops/update-feeds-loops.ts
+++ b/src/update-feeds-loops/update-feeds-loops.ts
@@ -248,7 +248,7 @@ export const runUpdateFeeds = async (providerName: ProviderName, chain: Chain, c
 
         // Update the state with the signed API URLs.
         const signedApiUrls = uniq(
-          processedBatches.reduce((acc, batch) => (batch ? [...acc, ...batch.signedApiUrls] : acc), [] as string[])
+          processedBatches.reduce<string[]>((acc, batch) => (batch ? [...acc, ...batch.signedApiUrls] : acc), [])
         );
         // Overwrite the state with the new signed API URLs instead of merging them to avoid stale URLs.
         updateState((draft) => set(draft, ['signedApiUrls', chainId, providerName], signedApiUrls));

--- a/src/update-feeds-loops/update-feeds-loops.ts
+++ b/src/update-feeds-loops/update-feeds-loops.ts
@@ -171,7 +171,7 @@ export const runUpdateFeeds = async (providerName: ProviderName, chain: Chain, c
         if (goFirstBatch.data === null) return;
         const { batch: firstBatch, activeDataFeedCount, blockNumber: firstBatchBlockNumber } = goFirstBatch.data;
         if (activeDataFeedCount === 0) {
-          logger.warn(`No active data feeds found.`);
+          logger.info(`No active data feeds found.`);
           return;
         }
         // NOTE: We need to explicitly handle the .catch here because it's possible that the promise settles before it's

--- a/src/update-feeds-loops/update-feeds-loops.ts
+++ b/src/update-feeds-loops/update-feeds-loops.ts
@@ -8,7 +8,7 @@ import { clearSponsorLastUpdateTimestamp, initializeGasState } from '../gas-pric
 import { logger } from '../logger';
 import { getState, updateState } from '../state';
 import type { ChainId, ProviderName } from '../types';
-import { sleep } from '../utils';
+import { getChainName, sleep } from '../utils';
 
 import {
   decodeActiveDataFeedCountResponse,
@@ -40,16 +40,15 @@ export const startUpdateFeedsLoops = async () => {
       // frequency.
       const staggerTimeMs = dataFeedUpdateIntervalMs / size(providers);
       logger.debug(`Starting update loops for chain.`, {
-        chainId,
+        chainName: getChainName(chainId),
         staggerTimeMs,
         providerNames: Object.keys(providers),
       });
 
       for (const providerName of Object.keys(providers)) {
-        logger.debug(`Initializing gas state.`, { chainId, providerName });
         initializeGasState(chainId, providerName);
 
-        logger.debug(`Starting update feed loop.`, { chainId, providerName });
+        logger.debug(`Starting update feeds loop.`, { chainName: getChainName(chainId), providerName });
         // Run the update feed loop manually for the first time, because setInterval first waits for the given period of
         // time before calling the callback function.
         void runUpdateFeeds(providerName, chain, chainId);
@@ -141,122 +140,125 @@ export const readActiveDataFeedBatch = async (
 };
 
 export const runUpdateFeeds = async (providerName: ProviderName, chain: Chain, chainId: ChainId) => {
-  await logger.runWithContext({ chainId, providerName, updateFeedsCoordinatorId: Date.now().toString() }, async () => {
-    // We do not expect this function to throw, but its possible that some execution path is incorrectly handled and we
-    // want to process the error ourselves, for example log the error using the configured format.
-    const goRunUpdateFeeds = await go(async () => {
-      const { dataFeedBatchSize, dataFeedUpdateInterval, providers, contracts } = chain;
-      const dataFeedUpdateIntervalMs = dataFeedUpdateInterval * 1000;
+  await logger.runWithContext(
+    { chainName: getChainName(chainId), providerName, updateFeedsCoordinatorId: Date.now().toString() },
+    async () => {
+      // We do not expect this function to throw, but its possible that some execution path is incorrectly handled and we
+      // want to process the error ourselves, for example log the error using the configured format.
+      const goRunUpdateFeeds = await go(async () => {
+        const { dataFeedBatchSize, dataFeedUpdateInterval, providers, contracts } = chain;
+        const dataFeedUpdateIntervalMs = dataFeedUpdateInterval * 1000;
 
-      // Create a provider and connect it to the AirseekerRegistry contract.
-      const provider = await createProvider(providers[providerName]!.url);
-      if (!provider) {
-        logger.warn('Failed to create provider. This is likely an RPC issue.');
-        return;
-      }
-      const airseekerRegistry = getAirseekerRegistry(contracts.AirseekerRegistry, provider);
-
-      logger.debug(`Fetching first batch of data feeds batches.`);
-      const firstBatchStartTimeMs = Date.now();
-      const goFirstBatch = await go(
-        async () => readActiveDataFeedBatch(airseekerRegistry, chainId, 0, dataFeedBatchSize),
-        { totalTimeoutMs: dataFeedUpdateIntervalMs }
-      );
-      if (!goFirstBatch.success) {
-        logger.error(`Failed to get first active data feeds batch.`, goFirstBatch.error);
-        return;
-      }
-
-      if (goFirstBatch.data === null) return;
-      const { batch: firstBatch, activeDataFeedCount, blockNumber: firstBatchBlockNumber } = goFirstBatch.data;
-      if (activeDataFeedCount === 0) {
-        logger.warn(`No active data feeds found.`);
-        return;
-      }
-      // NOTE: We need to explicitly handle the .catch here because it's possible that the promise settles before it's
-      // awaited, causing unhandled promise rejection. We do not expect this function to throw, but we want the promise
-      // chain to be handled correctly in case there is some unhandled error.
-      const processFirstBatchPromise: Promise<Error> | ReturnType<typeof processBatch> = processBatch(
-        firstBatch,
-        providerName,
-        provider,
-        chainId,
-        firstBatchBlockNumber
-      ).catch((error) => error);
-
-      // Calculate the stagger time.
-      const batchesCount = Math.ceil(activeDataFeedCount! / dataFeedBatchSize);
-      const firstBatchDurationMs = Date.now() - firstBatchStartTimeMs;
-      const staggerTimeMs = calculateStaggerTimeMs(batchesCount, firstBatchDurationMs, dataFeedUpdateIntervalMs);
-
-      // Wait the remaining stagger time required after fetching the first batch.
-      await sleep(Math.max(0, staggerTimeMs - firstBatchDurationMs));
-
-      // Fetch the rest of the batches in parallel in a staggered way and process them.
-      if (batchesCount > 1) {
-        logger.debug('Fetching batches of active data feeds.', { batchesCount, staggerTimeMs });
-      }
-      const processOtherBatchesPromises = range(1, batchesCount).map(async (batchIndex) => {
-        await sleep((batchIndex - 1) * staggerTimeMs);
-
-        const goBatch = await go(async () => {
-          logger.debug(`Fetching batch of active data feeds.`, { batchIndex });
-          const dataFeedBatchIndexStart = batchIndex * dataFeedBatchSize;
-          const dataFeedBatchIndexEnd = Math.min(activeDataFeedCount!, dataFeedBatchIndexStart + dataFeedBatchSize);
-          const activeBatch = await readActiveDataFeedBatch(
-            airseekerRegistry,
-            chainId,
-            dataFeedBatchIndexStart,
-            dataFeedBatchIndexEnd
-          );
-
-          return activeBatch;
-        });
-        if (!goBatch.success) {
-          logger.error(`Failed to get active data feeds batch.`, goBatch.error);
+        // Create a provider and connect it to the AirseekerRegistry contract.
+        const provider = await createProvider(providers[providerName]!.url);
+        if (!provider) {
+          logger.warn('Failed to create provider. This is likely an RPC issue.');
           return;
         }
-        if (goBatch.data === null) return;
-        const { batch, blockNumber } = goBatch.data;
+        const airseekerRegistry = getAirseekerRegistry(contracts.AirseekerRegistry, provider);
 
-        return processBatch(batch, providerName, provider, chainId, blockNumber);
-      });
+        logger.debug(`Fetching first batch of data feeds batches.`);
+        const firstBatchStartTimeMs = Date.now();
+        const goFirstBatch = await go(
+          async () => readActiveDataFeedBatch(airseekerRegistry, chainId, 0, dataFeedBatchSize),
+          { totalTimeoutMs: dataFeedUpdateIntervalMs }
+        );
+        if (!goFirstBatch.success) {
+          logger.error(`Failed to get first active data feeds batch.`, goFirstBatch.error);
+          return;
+        }
 
-      // Wait for all the batches to be processed and print stats from this run.
-      const processedBatches = await Promise.all([
-        // eslint-disable-next-line @typescript-eslint/promise-function-async
-        new Promise<Awaited<ReturnType<typeof processBatch>>>((resolve, reject) => {
-          return processFirstBatchPromise.then((result) => {
-            // eslint-disable-next-line promise/always-return
-            if (isError(result)) reject(result);
-            else resolve(result);
+        if (goFirstBatch.data === null) return;
+        const { batch: firstBatch, activeDataFeedCount, blockNumber: firstBatchBlockNumber } = goFirstBatch.data;
+        if (activeDataFeedCount === 0) {
+          logger.warn(`No active data feeds found.`);
+          return;
+        }
+        // NOTE: We need to explicitly handle the .catch here because it's possible that the promise settles before it's
+        // awaited, causing unhandled promise rejection. We do not expect this function to throw, but we want the promise
+        // chain to be handled correctly in case there is some unhandled error.
+        const processFirstBatchPromise: Promise<Error> | ReturnType<typeof processBatch> = processBatch(
+          firstBatch,
+          providerName,
+          provider,
+          chainId,
+          firstBatchBlockNumber
+        ).catch((error) => error);
+
+        // Calculate the stagger time.
+        const batchesCount = Math.ceil(activeDataFeedCount! / dataFeedBatchSize);
+        const firstBatchDurationMs = Date.now() - firstBatchStartTimeMs;
+        const staggerTimeMs = calculateStaggerTimeMs(batchesCount, firstBatchDurationMs, dataFeedUpdateIntervalMs);
+
+        // Wait the remaining stagger time required after fetching the first batch.
+        await sleep(Math.max(0, staggerTimeMs - firstBatchDurationMs));
+
+        // Fetch the rest of the batches in parallel in a staggered way and process them.
+        if (batchesCount > 1) {
+          logger.debug('Fetching batches of active data feeds.', { batchesCount, staggerTimeMs });
+        }
+        const processOtherBatchesPromises = range(1, batchesCount).map(async (batchIndex) => {
+          await sleep((batchIndex - 1) * staggerTimeMs);
+
+          const goBatch = await go(async () => {
+            logger.debug(`Fetching batch of active data feeds.`, { batchIndex });
+            const dataFeedBatchIndexStart = batchIndex * dataFeedBatchSize;
+            const dataFeedBatchIndexEnd = Math.min(activeDataFeedCount!, dataFeedBatchIndexStart + dataFeedBatchSize);
+            const activeBatch = await readActiveDataFeedBatch(
+              airseekerRegistry,
+              chainId,
+              dataFeedBatchIndexStart,
+              dataFeedBatchIndexEnd
+            );
+
+            return activeBatch;
           });
-        }),
-        ...processOtherBatchesPromises,
-      ]);
+          if (!goBatch.success) {
+            logger.error(`Failed to get active data feeds batch.`, goBatch.error);
+            return;
+          }
+          if (goBatch.data === null) return;
+          const { batch, blockNumber } = goBatch.data;
 
-      // Print stats from this run.
-      const skippedBatchesCount = processedBatches.filter((batch) => !batch).length;
-      const dataFeedUpdates = processedBatches.reduce((acc, batch) => acc + (batch ? batch.successCount : 0), 0);
-      const dataFeedUpdateFailures = processedBatches.reduce((acc, batch) => acc + (batch ? batch.errorCount : 0), 0);
-      logger.info(`Finished processing batches of active data feeds.`, {
-        skippedBatchesCount,
-        dataFeedUpdates,
-        dataFeedUpdateFailures,
+          return processBatch(batch, providerName, provider, chainId, blockNumber);
+        });
+
+        // Wait for all the batches to be processed and print stats from this run.
+        const processedBatches = await Promise.all([
+          // eslint-disable-next-line @typescript-eslint/promise-function-async
+          new Promise<Awaited<ReturnType<typeof processBatch>>>((resolve, reject) => {
+            return processFirstBatchPromise.then((result) => {
+              // eslint-disable-next-line promise/always-return
+              if (isError(result)) reject(result);
+              else resolve(result);
+            });
+          }),
+          ...processOtherBatchesPromises,
+        ]);
+
+        // Print stats from this run.
+        const skippedBatchesCount = processedBatches.filter((batch) => !batch).length;
+        const dataFeedUpdates = processedBatches.reduce((acc, batch) => acc + (batch ? batch.successCount : 0), 0);
+        const dataFeedUpdateFailures = processedBatches.reduce((acc, batch) => acc + (batch ? batch.errorCount : 0), 0);
+        logger.info(`Finished processing batches of active data feeds.`, {
+          skippedBatchesCount,
+          dataFeedUpdates,
+          dataFeedUpdateFailures,
+        });
+
+        // Update the state with the signed API URLs.
+        const signedApiUrls = uniq(
+          processedBatches.reduce((acc, batch) => (batch ? [...acc, ...batch.signedApiUrls] : acc), [] as string[])
+        );
+        // Overwrite the state with the new signed API URLs instead of merging them to avoid stale URLs.
+        updateState((draft) => set(draft, ['signedApiUrls', chainId, providerName], signedApiUrls));
       });
 
-      // Update the state with the signed API URLs.
-      const signedApiUrls = uniq(
-        processedBatches.reduce<string[]>((acc, batch) => (batch ? [...acc, ...batch.signedApiUrls] : acc), [])
-      );
-      // Overwrite the state with the new signed API URLs instead of merging them to avoid stale URLs.
-      updateState((draft) => set(draft, ['signedApiUrls', chainId, providerName], signedApiUrls));
-    });
-
-    if (!goRunUpdateFeeds.success) {
-      logger.error(`Unexpected error when updating data feeds feeds.`, goRunUpdateFeeds.error);
+      if (!goRunUpdateFeeds.success) {
+        logger.error(`Unexpected error when updating data feeds feeds.`, goRunUpdateFeeds.error);
+      }
     }
-  });
+  );
 };
 
 export const processBatch = async (

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -87,5 +87,5 @@ export const decodeBeaconValue = (encodedBeaconValue: string) => {
 };
 
 export const getChainName = (chainId: string) => {
-  return CHAINS.find((c) => c.id === chainId)?.name ?? 'unknown';
+  return CHAINS.find((c) => c.id === chainId)?.alias ?? 'unknown';
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,4 @@
+import { CHAINS } from '@api3/chains';
 import { goSync } from '@api3/promise-utils';
 import { ethers } from 'ethers';
 
@@ -83,4 +84,8 @@ export const decodeBeaconValue = (encodedBeaconValue: string) => {
   }
 
   return decodedBeaconValue;
+};
+
+export const getChainName = (chainId: string) => {
+  return CHAINS.find((c) => c.id === chainId)?.name ?? 'unknown';
 };

--- a/test/e2e/update-feeds.feature.ts
+++ b/test/e2e/update-feeds.feature.ts
@@ -86,6 +86,7 @@ it('updates blockchain data', async () => {
   );
   jest.spyOn(logger, 'debug');
   jest.spyOn(logger, 'info');
+  jest.spyOn(logger, 'warn');
   const blockNumber = await provider.getBlockNumber();
 
   await submitTransactions(
@@ -111,7 +112,7 @@ it('updates blockchain data', async () => {
     blockNumber
   );
 
-  expect(logger.debug).toHaveBeenCalledTimes(10);
+  expect(logger.debug).toHaveBeenCalledTimes(9);
   expect(logger.debug).toHaveBeenNthCalledWith(1, 'Creating calldatas.');
   expect(logger.debug).toHaveBeenNthCalledWith(2, 'Estimating gas limit.');
   expect(logger.debug).toHaveBeenNthCalledWith(3, 'Getting derived sponsor wallet.');
@@ -120,12 +121,13 @@ it('updates blockchain data', async () => {
   expect(logger.debug).toHaveBeenNthCalledWith(6, 'Getting gas price.');
   expect(logger.debug).toHaveBeenNthCalledWith(7, 'Fetching gas price and saving it to the state.');
   expect(logger.debug).toHaveBeenNthCalledWith(8, 'Purging old gas prices.');
-  expect(logger.debug).toHaveBeenNthCalledWith(
-    9,
-    'No historical gas prices to compute the percentile. Using the provider recommended gas price.'
-  );
-  expect(logger.debug).toHaveBeenNthCalledWith(10, 'Setting timestamp of the original update transaction.');
+  expect(logger.debug).toHaveBeenNthCalledWith(9, 'Setting timestamp of the original update transaction.');
   expect(logger.info).toHaveBeenCalledTimes(2);
   expect(logger.info).toHaveBeenNthCalledWith(1, 'Updating data feed.', expect.anything());
   expect(logger.info).toHaveBeenNthCalledWith(2, 'Successfully updated data feed.');
+  expect(logger.warn).toHaveBeenCalledTimes(1);
+  expect(logger.warn).toHaveBeenNthCalledWith(
+    1,
+    'No historical gas prices to compute the percentile. Using the provider recommended gas price.'
+  );
 });


### PR DESCRIPTION
Closes https://github.com/api3dao/airseeker-v2/issues/189
Closes https://github.com/api3dao/airseeker-v2/issues/198

## Rationale

The INFO logs logged very little. This is now changed because both "data fetching loop" and "update feeds loops" now log a message. I went through each log one-by-one and I updated the severity whenever I felt it's a good idea.

I also changed that we log the chain name instead of chain ID.