### PR TITLE
Fix gas fetching, improve tests

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,18 +18,19 @@ module.exports = {
   extends: ['./node_modules/@api3/commons/dist/eslint/universal', './node_modules/@api3/commons/dist/eslint/jest'],
   plugins: ['@typescript-eslint', 'import', 'jest'],
   rules: {
-    'unicorn/prefer-top-level-await': 'off',
     'unicorn/no-process-exit': 'off',
-    '@typescript-eslint/max-params': 'off',
+    'unicorn/prefer-top-level-await': 'off',
 
     // Typescript
-    '@typescript-eslint/no-var-requires': 'off',
-    '@typescript-eslint/no-dynamic-delete': 'off',
     '@typescript-eslint/consistent-return': 'off', // Does not play with no useless undefined when function return type is "T | undefined" and does not have a fixer.
+    '@typescript-eslint/max-params': 'off',
+    '@typescript-eslint/no-dynamic-delete': 'off',
+    '@typescript-eslint/no-var-requires': 'off',
     '@typescript-eslint/use-unknown-in-catch-callback-variable': 'off',
 
     // Lodash
     'lodash/prefer-immutable-method': 'off',
+    'lodash/prop-shorthand': 'off',
 
     // Jest
     'jest/no-hooks': 'off',

--- a/src/gas-price/gas-price.test.ts
+++ b/src/gas-price/gas-price.test.ts
@@ -154,9 +154,10 @@ describe(getRecommendedGasPrice.name, () => {
     expect(logger.warn).toHaveBeenNthCalledWith(1, 'There is no gas price stored.');
   });
 
-  it("uses sanitized percentile gas price if it's above the percentile", () => {
+  it('uses sanitized percentile gas price if the latest is above the percentile', () => {
     jest.spyOn(Date, 'now').mockReturnValue(dateNowMock);
     updateState((draft) => {
+      // Make sure there are enough historical gas prices to sanitize.
       draft.gasPrices[chainId]![providerName]!.gasPrices = range(30).map((_, i) => ({
         price: ethers.parseUnits(`10`, 'gwei') - BigInt(i) * 100_000_000n,
         timestamp: timestampMock - 30 * (i + 1),
@@ -219,7 +220,7 @@ describe(getRecommendedGasPrice.name, () => {
     expect(logger.warn).toHaveBeenCalledTimes(0);
   });
 
-  it('applies scaling if the transaction is a retry of a pending transaction', async () => {
+  it('applies scaling if the transaction is a retry of a pending transaction', () => {
     jest.spyOn(Date, 'now').mockReturnValue(dateNowMock);
     updateState((draft) => {
       draft.gasPrices[chainId]![providerName]!.gasPrices = [];

--- a/src/gas-price/gas-price.ts
+++ b/src/gas-price/gas-price.ts
@@ -158,7 +158,7 @@ export const getRecommendedGasPrice = (chainId: string, providerName: string, sp
   let latestGasPrice: bigint | undefined;
   // Use the latest gas price that is stored in the state. We assume that the gas price is fetched frequently and has
   // been fetched immediately before making this call. In case it fails, we fallback to the previously stored gas price.
-  if (!latestGasPrice && gasPrices.length > 0) {
+  if (gasPrices.length > 0) {
     const lastSavedTimestamp = Math.max(...gasPrices.map((gasPrice) => gasPrice.timestamp));
     latestGasPrice = gasPrices.find((gasPrice) => gasPrice.timestamp === lastSavedTimestamp)!.price;
   }

--- a/src/gas-price/gas-price.ts
+++ b/src/gas-price/gas-price.ts
@@ -1,6 +1,6 @@
 import { go } from '@api3/promise-utils';
 import type { ethers } from 'ethers';
-import { remove } from 'lodash';
+import { maxBy, remove } from 'lodash';
 
 import { logger } from '../logger';
 import { getState, updateState } from '../state';
@@ -117,7 +117,7 @@ export const fetchAndStoreGasPrice = async (
   });
   const gasPrice = goGasPrice.data;
   if (!goGasPrice.success) {
-    if (!goGasPrice.success) logger.error('Failed to fetch gas price from RPC provider.', goGasPrice.error);
+    logger.error('Failed to fetch gas price from RPC provider.', goGasPrice.error);
     return null;
   }
   if (!gasPrice) {
@@ -158,10 +158,7 @@ export const getRecommendedGasPrice = (chainId: string, providerName: string, sp
   let latestGasPrice: bigint | undefined;
   // Use the latest gas price that is stored in the state. We assume that the gas price is fetched frequently and has
   // been fetched immediately before making this call. In case it fails, we fallback to the previously stored gas price.
-  if (gasPrices.length > 0) {
-    const lastSavedTimestamp = Math.max(...gasPrices.map((gasPrice) => gasPrice.timestamp));
-    latestGasPrice = gasPrices.find((gasPrice) => gasPrice.timestamp === lastSavedTimestamp)!.price;
-  }
+  if (gasPrices.length > 0) latestGasPrice = maxBy(gasPrices, (x) => x.timestamp)!.price;
   if (!latestGasPrice) {
     logger.warn('There is no gas price stored.');
     return null;

--- a/src/gas-price/gas-price.ts
+++ b/src/gas-price/gas-price.ts
@@ -102,6 +102,35 @@ export const calculateScalingMultiplier = (
     maxScalingMultiplier
   );
 
+export const fetchAndStoreGasPrice = async (
+  chainId: string,
+  providerName: string,
+  provider: ethers.JsonRpcProvider
+) => {
+  // Get the provider recommended gas price and save it to the state
+  logger.debug('Fetching gas price and saving it to the state.');
+  const goGasPrice = await go(async () => {
+    const feeData = await provider.getFeeData();
+    // We assume the legacy gas price will always exist. See:
+    // https://api3workspace.slack.com/archives/C05TQPT7PNJ/p1699098552350519
+    return feeData.gasPrice;
+  });
+  const gasPrice = goGasPrice.data;
+  if (!goGasPrice.success || !gasPrice) {
+    if (!goGasPrice.success) logger.error('Failed to fetch gas price from RPC provider.', goGasPrice.error);
+    if (!gasPrice) logger.error('No gas price returned from RPC provider.');
+    return null;
+  }
+
+  const state = getState();
+  const {
+    gasSettings: { sanitizationSamplingWindow },
+  } = state.config.chains[chainId]!;
+  saveGasPrice(chainId, providerName, gasPrice);
+  purgeOldGasPrices(chainId, providerName, sanitizationSamplingWindow);
+  return gasPrice;
+};
+
 /**
  *  Calculates the gas price to be used in a transaction based on sanitization and scaling settings.
  * @param chainId
@@ -110,12 +139,7 @@ export const calculateScalingMultiplier = (
  * @param gasSettings
  * @param sponsorWalletAddress
  */
-export const getRecommendedGasPrice = async (
-  chainId: string,
-  providerName: string,
-  provider: ethers.JsonRpcProvider,
-  sponsorWalletAddress: string
-) => {
+export const getRecommendedGasPrice = (chainId: string, providerName: string, sponsorWalletAddress: string) => {
   const state = getState();
   const { gasPrices, sponsorLastUpdateTimestamp } = state.gasPrices[chainId]![providerName]!;
   const {
@@ -126,40 +150,21 @@ export const getRecommendedGasPrice = async (
       scalingWindow,
       maxScalingMultiplier,
     },
-    dataFeedUpdateInterval,
   } = state.config.chains[chainId]!;
 
-  // Get the provider recommended gas price and save it to the state
-  logger.debug('Fetching gas price and saving it to the state.');
-  const goGasPrice = await go(async () => {
-    const feeData = await provider.getFeeData();
-    // We assume the legacy gas price will always exist. See:
-    // https://api3workspace.slack.com/archives/C05TQPT7PNJ/p1699098552350519
-    return feeData.gasPrice;
-  });
-  let gasPrice = goGasPrice.data;
-  if (!goGasPrice.success) logger.error('Failed to fetch gas price from RPC provider.', goGasPrice.error);
-  if (gasPrice) saveGasPrice(chainId, providerName, gasPrice);
-
-  // If the gas price from RPC provider is not available, use the last saved gas price (provided it's fresh enough)
-  if (!gasPrice && gasPrices.length > 0) {
+  let latestGasPrice: bigint | undefined;
+  // Use the latest gas price that is stored in the state. We assume that the gas price is fetched frequently and has
+  // been fetched immediately before making this call. In case it fails, we fallback to the previously stored gas price.
+  if (!latestGasPrice && gasPrices.length > 0) {
     const lastSavedTimestamp = Math.max(...gasPrices.map((gasPrice) => gasPrice.timestamp));
-    const lastSavedGasPrice = gasPrices.find((gasPrice) => gasPrice.timestamp === lastSavedTimestamp)!.price;
-
-    if (lastSavedTimestamp >= Math.floor(Date.now() / 1000) - 10 * dataFeedUpdateInterval) {
-      gasPrice = lastSavedGasPrice;
-    }
+    latestGasPrice = gasPrices.find((gasPrice) => gasPrice.timestamp === lastSavedTimestamp)!.price;
   }
-  if (!gasPrice) {
+  if (!latestGasPrice) {
     logger.warn('There is no gas price to use. Skipping update.');
     return null;
   }
 
-  logger.debug('Purging old gas prices.');
-  purgeOldGasPrices(chainId, providerName, sanitizationSamplingWindow);
-
   const lastUpdateTimestamp = sponsorLastUpdateTimestamp[sponsorWalletAddress];
-
   // Check if the next update is a retry of a pending transaction
   if (lastUpdateTimestamp) {
     const pendingPeriod = Math.floor(Date.now() / 1000) - lastUpdateTimestamp;
@@ -170,8 +175,8 @@ export const getRecommendedGasPrice = async (
       scalingWindow
     );
 
-    logger.warn('Scaling gas price.', { gasPrice: gasPrice.toString(), multiplier, pendingPeriod });
-    return multiplyBigNumber(gasPrice, multiplier);
+    logger.warn('Scaling gas price.', { gasPrice: latestGasPrice.toString(), multiplier, pendingPeriod });
+    return multiplyBigNumber(latestGasPrice, multiplier);
   }
 
   // Check that there are enough entries in the stored gas prices to determine whether to use sanitization or not
@@ -188,25 +193,25 @@ export const getRecommendedGasPrice = async (
   );
   if (!percentileGasPrice) {
     logger.warn('No historical gas prices to compute the percentile. Using the provider recommended gas price.');
-    return multiplyBigNumber(gasPrice, recommendedGasPriceMultiplier);
+    return multiplyBigNumber(latestGasPrice, recommendedGasPriceMultiplier);
   }
 
   // Log a warning if there is not enough historical data to sanitize the gas price but the price could be sanitized
-  if (!hasSufficientSanitizationData && gasPrice > percentileGasPrice) {
+  if (!hasSufficientSanitizationData && latestGasPrice > percentileGasPrice) {
     logger.warn('Gas price could be sanitized but there is not enough historical data.', {
-      gasPrice: gasPrice.toString(),
+      gasPrice: latestGasPrice.toString(),
       percentileGasPrice: percentileGasPrice.toString(),
     });
   }
 
   // If necessary, sanitize the gas price and log a warning because this should not happen under normal circumstances
-  if (hasSufficientSanitizationData && gasPrice > percentileGasPrice) {
+  if (hasSufficientSanitizationData && latestGasPrice > percentileGasPrice) {
     logger.warn('Sanitizing gas price.', {
-      gasPrice: gasPrice.toString(),
+      gasPrice: latestGasPrice.toString(),
       percentileGasPrice: percentileGasPrice.toString(),
     });
     return multiplyBigNumber(percentileGasPrice, recommendedGasPriceMultiplier);
   }
 
-  return multiplyBigNumber(gasPrice, recommendedGasPriceMultiplier);
+  return multiplyBigNumber(latestGasPrice, recommendedGasPriceMultiplier);
 };

--- a/src/update-feeds-loops/submit-transactions.test.ts
+++ b/src/update-feeds-loops/submit-transactions.test.ts
@@ -355,7 +355,7 @@ describe(submitTransactionsModule.submitTransaction.name, () => {
     jest.spyOn(logger, 'debug');
     jest.spyOn(logger, 'info');
     jest.spyOn(submitTransactionsModule, 'estimateMulticallGasLimit').mockResolvedValue(BigInt(500_000));
-    jest.spyOn(gasPriceModule, 'getRecommendedGasPrice').mockResolvedValue(BigInt(100_000_000));
+    jest.spyOn(gasPriceModule, 'getRecommendedGasPrice').mockReturnValue(BigInt(100_000_000));
     jest.spyOn(submitTransactionsModule, 'hasSponsorPendingTransaction').mockReturnValue(false);
     const api3ServerV1 = generateMockApi3ServerV1();
     jest.spyOn(api3ServerV1, 'connect').mockReturnValue(api3ServerV1);
@@ -412,7 +412,7 @@ describe(submitTransactionsModule.submitTransaction.name, () => {
       sponsorWalletAddress: '0xA772F7b103BBecA3Bb6C74Be41fCc2c192C8146c',
     });
     expect(logger.debug).toHaveBeenNthCalledWith(5, 'Getting nonce.');
-    expect(logger.debug).toHaveBeenNthCalledWith(6, 'Getting gas price.');
+    expect(logger.debug).toHaveBeenNthCalledWith(6, 'Getting recommended gas price.');
     expect(logger.debug).toHaveBeenNthCalledWith(7, 'Setting timestamp of the original update transaction.');
   });
 });

--- a/src/update-feeds-loops/submit-transactions.ts
+++ b/src/update-feeds-loops/submit-transactions.ts
@@ -90,8 +90,8 @@ export const submitTransaction = async (
         logger.debug('Getting nonce.');
         const nonce = await provider.getTransactionCount(sponsorWallet.address, blockNumber);
 
-        logger.debug('Getting gas price.');
-        const gasPrice = await getRecommendedGasPrice(chainId, providerName, provider, sponsorWallet.address);
+        logger.debug('Getting recommended gas price.');
+        const gasPrice = getRecommendedGasPrice(chainId, providerName, sponsorWallet.address);
         if (!gasPrice) return null;
 
         // We want to set the timestamp of the first update transaction. We can determine if the transaction is the

--- a/src/update-feeds-loops/update-feeds-loops.test.ts
+++ b/src/update-feeds-loops/update-feeds-loops.test.ts
@@ -178,7 +178,10 @@ describe(updateFeedsLoopsModule.runUpdateFeeds.name, () => {
       ),
     };
     const airseekerRegistry = generateMockAirseekerRegistry();
-    jest.spyOn(contractsModule, 'createProvider').mockResolvedValue(123 as any as ethers.JsonRpcProvider);
+    const getFeeDataSpy = jest.fn().mockResolvedValue({ gasPrice: ethers.parseUnits('5', 'gwei') });
+    jest
+      .spyOn(contractsModule, 'createProvider')
+      .mockResolvedValue({ getFeeData: getFeeDataSpy } as any as ethers.JsonRpcProvider);
     jest
       .spyOn(contractsModule, 'getAirseekerRegistry')
       .mockReturnValue(airseekerRegistry as unknown as AirseekerRegistry);
@@ -268,20 +271,22 @@ describe(updateFeedsLoopsModule.runUpdateFeeds.name, () => {
       'Failed to get active data feeds batch.',
       new Error('One of the multicalls failed')
     );
-    expect(logger.debug).toHaveBeenCalledTimes(6);
+    expect(logger.debug).toHaveBeenCalledTimes(8);
     expect(logger.debug).toHaveBeenNthCalledWith(1, 'Fetching first batch of data feeds batches.');
     expect(logger.debug).toHaveBeenNthCalledWith(2, 'Processing batch of active data feeds.', expect.anything());
-    expect(logger.debug).toHaveBeenNthCalledWith(3, 'Fetching batches of active data feeds.', {
+    expect(logger.debug).toHaveBeenNthCalledWith(3, 'Fetching gas price and saving it to the state.');
+    expect(logger.debug).toHaveBeenNthCalledWith(4, 'Fetching batches of active data feeds.', {
       batchesCount: 3,
       staggerTimeMs: 50,
     });
-    expect(logger.debug).toHaveBeenNthCalledWith(4, 'Fetching batch of active data feeds.', {
+    expect(logger.debug).toHaveBeenNthCalledWith(5, 'Fetching batch of active data feeds.', {
       batchIndex: 1,
     });
-    expect(logger.debug).toHaveBeenNthCalledWith(5, 'Fetching batch of active data feeds.', {
+    expect(logger.debug).toHaveBeenNthCalledWith(6, 'Fetching batch of active data feeds.', {
       batchIndex: 2,
     });
-    expect(logger.debug).toHaveBeenNthCalledWith(6, 'Processing batch of active data feeds.', expect.anything());
+    expect(logger.debug).toHaveBeenNthCalledWith(7, 'Processing batch of active data feeds.', expect.anything());
+    expect(logger.debug).toHaveBeenNthCalledWith(8, 'Fetching gas price and saving it to the state.');
 
     expect(logger.info).toHaveBeenCalledTimes(1);
     expect(logger.info).toHaveBeenNthCalledWith(1, 'Finished processing batches of active data feeds.', {

--- a/src/update-feeds-loops/update-feeds-loops.ts
+++ b/src/update-feeds-loops/update-feeds-loops.ts
@@ -4,7 +4,7 @@ import type { ethers } from 'ethers';
 import { isError, range, set, size, uniq } from 'lodash';
 
 import type { Chain } from '../config/schema';
-import { clearSponsorLastUpdateTimestamp, initializeGasState } from '../gas-price';
+import { clearSponsorLastUpdateTimestamp, fetchAndStoreGasPrice, initializeGasState } from '../gas-price';
 import { logger } from '../logger';
 import { getState, updateState } from '../state';
 import type { ChainId, ProviderName } from '../types';
@@ -338,6 +338,10 @@ export const processBatch = async (
       clearSponsorLastUpdateTimestamp(chainId, providerName, sponsorWalletAddress);
     }
   }
+
+  // Fetch the gas price regardless of whether there are any feeds to be updated or not in order for gas oracle to
+  // maintain historical gas prices.
+  await fetchAndStoreGasPrice(chainId, providerName, provider);
 
   const updatedFeeds = await submitTransactions(
     chainId,

--- a/test/e2e/update-feeds.feature.ts
+++ b/test/e2e/update-feeds.feature.ts
@@ -1,4 +1,4 @@
-import { initializeGasState } from '../../src/gas-price';
+import { fetchAndStoreGasPrice, initializeGasState } from '../../src/gas-price';
 import { logger } from '../../src/logger';
 import * as stateModule from '../../src/state';
 import { runUpdateFeeds } from '../../src/update-feeds-loops';
@@ -88,6 +88,7 @@ it('updates blockchain data', async () => {
   jest.spyOn(logger, 'info');
   jest.spyOn(logger, 'warn');
   const blockNumber = await provider.getBlockNumber();
+  await fetchAndStoreGasPrice(chainId, providerName, provider);
 
   await submitTransactions(
     chainId,
@@ -112,22 +113,17 @@ it('updates blockchain data', async () => {
     blockNumber
   );
 
-  expect(logger.debug).toHaveBeenCalledTimes(9);
-  expect(logger.debug).toHaveBeenNthCalledWith(1, 'Creating calldatas.');
-  expect(logger.debug).toHaveBeenNthCalledWith(2, 'Estimating gas limit.');
-  expect(logger.debug).toHaveBeenNthCalledWith(3, 'Getting derived sponsor wallet.');
-  expect(logger.debug).toHaveBeenNthCalledWith(4, 'Derived new sponsor wallet.', expect.anything());
-  expect(logger.debug).toHaveBeenNthCalledWith(5, 'Getting nonce.');
-  expect(logger.debug).toHaveBeenNthCalledWith(6, 'Getting gas price.');
-  expect(logger.debug).toHaveBeenNthCalledWith(7, 'Fetching gas price and saving it to the state.');
-  expect(logger.debug).toHaveBeenNthCalledWith(8, 'Purging old gas prices.');
-  expect(logger.debug).toHaveBeenNthCalledWith(9, 'Setting timestamp of the original update transaction.');
+  expect(logger.debug).toHaveBeenCalledTimes(8);
+  expect(logger.debug).toHaveBeenNthCalledWith(1, 'Fetching gas price and saving it to the state.');
+  expect(logger.debug).toHaveBeenNthCalledWith(2, 'Creating calldatas.');
+  expect(logger.debug).toHaveBeenNthCalledWith(3, 'Estimating gas limit.');
+  expect(logger.debug).toHaveBeenNthCalledWith(4, 'Getting derived sponsor wallet.');
+  expect(logger.debug).toHaveBeenNthCalledWith(5, 'Derived new sponsor wallet.', expect.anything());
+  expect(logger.debug).toHaveBeenNthCalledWith(6, 'Getting nonce.');
+  expect(logger.debug).toHaveBeenNthCalledWith(7, 'Getting recommended gas price.');
+  expect(logger.debug).toHaveBeenNthCalledWith(8, 'Setting timestamp of the original update transaction.');
   expect(logger.info).toHaveBeenCalledTimes(2);
   expect(logger.info).toHaveBeenNthCalledWith(1, 'Updating data feed.', expect.anything());
   expect(logger.info).toHaveBeenNthCalledWith(2, 'Successfully updated data feed.');
-  expect(logger.warn).toHaveBeenCalledTimes(1);
-  expect(logger.warn).toHaveBeenNthCalledWith(
-    1,
-    'No historical gas prices to compute the percentile. Using the provider recommended gas price.'
-  );
+  expect(logger.warn).toHaveBeenCalledTimes(0);
 });


### PR DESCRIPTION
Closes https://github.com/api3dao/airseeker-v2/issues/218

## Rationale

[Here](https://api3workspace.slack.com/archives/C05TQPT7PNJ/p1697793195536069) we've decided to make the gas fetching part of the "main" (update feeds) loop. The problem is that the gas was fetched from the RPC only before an update transaction was submitted.

Now it's fetched during the processing of each batch.