### PR TITLE
Downgrade is-wsl dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "hardhat": "^2.22.2",
     "hardhat-deploy": "^0.12.2",
     "husky": "^9.0.11",
-    "is-wsl": "^3.1.0",
+    "is-wsl": "^2.2.0",
     "jest": "^29.7.0",
     "nodemon": "^3.1.0",
     "prettier": "^3.2.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,8 +86,8 @@ devDependencies:
     specifier: ^9.0.11
     version: 9.0.11
   is-wsl:
-    specifier: ^3.1.0
-    version: 3.1.0
+    specifier: ^2.2.0
+    version: 2.2.0
   jest:
     specifier: ^29.7.0
     version: 29.7.0(@types/node@20.12.2)(ts-node@10.9.2)
@@ -5084,9 +5084,9 @@ packages:
     dependencies:
       has-tostringtag: 1.0.0
 
-  /is-docker@3.0.0:
-    resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+  /is-docker@2.2.1:
+    resolution: {integrity: sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==}
+    engines: {node: '>=8'}
     hasBin: true
     dev: true
 
@@ -5144,14 +5144,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: false
-
-  /is-inside-container@1.0.0:
-    resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==}
-    engines: {node: '>=14.16'}
-    hasBin: true
-    dependencies:
-      is-docker: 3.0.0
-    dev: true
 
   /is-map@2.0.2:
     resolution: {integrity: sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg==}
@@ -5239,11 +5231,11 @@ packages:
       get-intrinsic: 1.2.2
     dev: false
 
-  /is-wsl@3.1.0:
-    resolution: {integrity: sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==}
-    engines: {node: '>=16'}
+  /is-wsl@2.2.0:
+    resolution: {integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==}
+    engines: {node: '>=8'}
     dependencies:
-      is-inside-container: 1.0.0
+      is-docker: 2.2.1
     dev: true
 
   /isarray@1.0.0:

--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,7 @@
   "extends": ["config:base"],
   "packageRules": [
     {
-      "matchPackageNames": ["node"],
+      "matchPackageNames": ["node", "is-wsl"],
       "enabled": false
     },
     {


### PR DESCRIPTION
The version 3 is ESM only and doesn't work. To release 2.3.0 I downgraded it.