### PR TITLE
Fix dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,4 +23,4 @@ RUN chown --recursive node:node /app
 USER node
 # Start the Airseeker.
 ENV NODE_ENV=production
-ENTRYPOINT ["node", "dist/index.js"]
+ENTRYPOINT ["node", "dist/src/index.js"]

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { cwd } from 'node:process';
 
 import { goSync } from '@api3/promise-utils';
 import dotenv from 'dotenv';
@@ -7,7 +8,11 @@ import dotenv from 'dotenv';
 import { configSchema } from './schema';
 import { interpolateSecrets, parseSecrets } from './utils';
 
-export const getConfigPath = () => join(__dirname, '../../config');
+// When Airnode feed is built, the "/dist" file contains "src" folder and "package.json" and the config is expected to
+// be located next to the "/dist" folder. When run in development, the config is expected to be located next to the
+// "src" folder (one less import level). We resolve the config by CWD as a workaround. Since the Airnode feed is
+// dockerized, this is hidden from the user.
+const getConfigPath = () => join(cwd(), './config');
 
 export const loadRawConfig = () => JSON.parse(readFileSync(join(getConfigPath(), 'airseeker.json'), 'utf8'));
 

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -10,7 +10,7 @@ import { interpolateSecrets, parseSecrets } from './utils';
 
 // When Airnode feed is built, the "/dist" file contains "src" folder and "package.json" and the config is expected to
 // be located next to the "/dist" folder. When run in development, the config is expected to be located next to the
-// "src" folder (one less import level). We resolve the config by CWD as a workaround. Since the Airnode feed is
+// "src" folder (one less import level). We resolve the config by CWD as a workaround. Since the Airseeker is
 // dockerized, this is hidden from the user.
 const getConfigPath = () => join(cwd(), './config');
 


### PR DESCRIPTION
Closes https://github.com/api3dao/airseeker-v2/issues/229

I tested this locally and it works. The change is similar to https://github.com/api3dao/signed-api/blob/7f30af2a5ada7abd7dc168da1032683b966410f8/packages/airnode-feed/src/validation/config.ts#L19