### PR TITLE
Try to detect submit tx failures

### DIFF
--- a/src/update-feeds-loops/submit-transactions.ts
+++ b/src/update-feeds-loops/submit-transactions.ts
@@ -118,7 +118,8 @@ export const submitTransaction = async (
         });
         if (!goMulticall.success) {
           // It seems that in practice, this code is widely used. We can do a best-effort attempt to determine the error
-          // reason. Many times, the error is acceptable and results from the way Airseeker is designed.
+          // reason. Many times, the error is acceptable and results from the way Airseeker is designed. We can use
+          // different log levels and messages and have better alerts.
           const errorCode = (goMulticall.error as any).code;
           switch (errorCode) {
             case 'REPLACEMENT_UNDERPRICED': {


### PR DESCRIPTION
Closes https://github.com/api3dao/airseeker-v2/issues/243

## Rationale

There are other grafana [error codes](https://api3.grafana.net/explore?schemaVersion=1&panes=%7B%22ziv%22:%7B%22datasource%22:%22grafanacloud-logs%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22expr%22:%22%7Bapp%3D%5C%22airseeker-v2%5C%22%7D%20%7C%3D%20%60Failed%20to%20submit%20the%20multicall%20transaction.%60%20%21%3D%20%60NONCE_EXPIRED%60%20%21%3D%20%60INSUFFICIENT_FUNDS%60%22,%22queryType%22:%22range%22,%22datasource%22:%7B%22type%22:%22loki%22,%22uid%22:%22grafanacloud-logs%22%7D,%22editorMode%22:%22builder%22%7D%5D,%22range%22:%7B%22from%22:%22now-30d%22,%22to%22:%22now%22%7D,%22panelsState%22:%7B%22logs%22:%7B%22logs%22:%7B%22visualisationType%22:%22logs%22%7D%7D%7D%7D%7D&orgId=1) but these are generic and rare. I don't want to do any message parsing so only relying on the error code.

I expect this will help with making the alert more actionable.