### PR TITLE
Stagger Signed API calls

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,3 @@
-export const HTTP_SIGNED_DATA_API_TIMEOUT_MULTIPLIER = 0.9;
-
 export const RPC_PROVIDER_TIMEOUT_MS = 120_000;
 
 export const HUNDRED_PERCENT = 10n ** 8n;

--- a/src/data-fetcher-loop/data-fetcher-loop.test.ts
+++ b/src/data-fetcher-loop/data-fetcher-loop.test.ts
@@ -71,4 +71,24 @@ describe('data fetcher', () => {
       10_000
     );
   });
+
+  it('handles parsing error from Signed API', async () => {
+    mockedAxios.mockResolvedValue(
+      Promise.resolve({
+        status: 200,
+        data: {
+          count: 1,
+          data: {
+            '0x91be0acf2d58a15c7cf687edabe4e255fdb27fbb77eba2a52f3bb3b46c99ec04': {
+              // Missing many properties that should be present
+              signature:
+                '0x0fe25ad7debe4d018aa53acfe56d84f35c8bedf58574611f5569a8d4415e342311c093bfe0648d54e0a02f13987ac4b033b24220880638df9103a60d4f74090b1c',
+            },
+          },
+        },
+      })
+    );
+
+    await expect(dataFetcherLoopModule.callSignedApi('some-url', 10_000)).resolves.toBeNull();
+  });
 });

--- a/src/data-fetcher-loop/data-fetcher-loop.test.ts
+++ b/src/data-fetcher-loop/data-fetcher-loop.test.ts
@@ -68,7 +68,7 @@ describe('data fetcher', () => {
     expect(dataFetcherLoopModule.callSignedApi).toHaveBeenNthCalledWith(
       1,
       'http://127.0.0.1:8090/0xC04575A2773Da9Cd23853A69694e02111b2c4182',
-      9000
+      10_000
     );
   });
 });

--- a/src/data-fetcher-loop/data-fetcher-loop.ts
+++ b/src/data-fetcher-loop/data-fetcher-loop.ts
@@ -60,9 +60,13 @@ export const callSignedApi = async (url: string, timeout: number): Promise<Signe
     return null;
   }
 
-  const { data } = signedApiResponseSchema.parse(goAxiosCall.data?.data);
+  const parseResult = signedApiResponseSchema.safeParse(goAxiosCall.data?.data);
+  if (!parseResult.success) {
+    logger.warn('Failed to parse signed API response.', { url });
+    return null;
+  }
 
-  return Object.values(data);
+  return Object.values(parseResult.data.data);
 };
 
 export const runDataFetcher = async () => {

--- a/src/data-fetcher-loop/data-fetcher-loop.ts
+++ b/src/data-fetcher-loop/data-fetcher-loop.ts
@@ -56,7 +56,7 @@ export const callSignedApi = async (url: string, timeout: number): Promise<Signe
   );
 
   if (!goAxiosCall.success) {
-    logger.warn('Failed to fetch data from signed API.', parseAxiosError(goAxiosCall.error));
+    logger.warn('Failed to fetch data from signed API.', { url, ...parseAxiosError(goAxiosCall.error) });
     return null;
   }
 

--- a/src/data-fetcher-loop/data-fetcher-loop.ts
+++ b/src/data-fetcher-loop/data-fetcher-loop.ts
@@ -2,10 +2,10 @@ import { go } from '@api3/promise-utils';
 import axios, { type AxiosResponse, type AxiosError } from 'axios';
 import { pick, uniq } from 'lodash';
 
-import { HTTP_SIGNED_DATA_API_TIMEOUT_MULTIPLIER } from '../constants';
 import { logger } from '../logger';
 import { getState } from '../state';
 import { signedApiResponseSchema, type SignedData } from '../types';
+import { sleep } from '../utils';
 
 import { purgeOldSignedData, saveSignedData } from './signed-data-state';
 
@@ -67,8 +67,6 @@ export const callSignedApi = async (url: string, timeout: number): Promise<Signe
 
 export const runDataFetcher = async () => {
   return logger.runWithContext({ dataFetcherCoordinatorId: Date.now().toString() }, async () => {
-    logger.info('Running data fetcher.');
-
     const state = getState();
     const {
       config: { signedDataFetchInterval },
@@ -77,32 +75,33 @@ export const runDataFetcher = async () => {
     const signedDataFetchIntervalMs = signedDataFetchInterval * 1000;
 
     // Better to log the non-decomposed object to see which URL comes from which chain-provider group.
-    logger.debug('Fetching data from signed APIs.', { signedApiUrls });
+    logger.debug('Signed API URLs.', { signedApiUrls });
     const urls = uniq(
       Object.values(signedApiUrls)
         .map((urlsPerProvider) => Object.values(urlsPerProvider))
         .flat(2)
     );
 
+    const urlCount = urls.length;
+    const staggerTimeMs = signedDataFetchIntervalMs / urlCount;
+    logger.info('Fetching signed data', { urlCount, staggerTimeMs });
     const fetchResults = await Promise.all(
-      urls.map(async (url) =>
-        go(
-          async () => {
-            const signedDataApiResponse = await callSignedApi(
-              url,
-              Math.ceil(signedDataFetchIntervalMs * HTTP_SIGNED_DATA_API_TIMEOUT_MULTIPLIER)
-            );
-            if (!signedDataApiResponse) return;
+      urls.map(async (url, index) => {
+        await sleep(staggerTimeMs * index);
 
-            for (const signedData of signedDataApiResponse) {
-              saveSignedData(signedData);
-            }
-          },
-          { totalTimeoutMs: signedDataFetchIntervalMs }
-        )
-      )
+        // NOTE: We allow each Signed API call to take full signedDataFetchIntervalMs. Because these calls are
+        // staggered, it means that there can be pending requests from different data fetcher loops happening at the
+        // same time. This does not matter much, because we only save the freshest signed data.
+        const signedDataApiResponse = await callSignedApi(url, signedDataFetchIntervalMs);
+        if (!signedDataApiResponse) return;
+
+        for (const signedData of signedDataApiResponse) {
+          saveSignedData(signedData);
+        }
+      })
     );
 
+    // Remove old signed data to keep the state clean.
     purgeOldSignedData();
 
     return fetchResults;


### PR DESCRIPTION
Closes https://github.com/api3dao/airseeker-v2/issues/255

## Rationale

I was thinking about adding a static delay between the requests, but that is ad-hoc. Instead, I chose to follow the same principle that we do in the update feeds loop. The batches are staggered and [runUpdateFeeds](https://github.com/api3dao/airseeker-v2/blob/96924b62c87f0a2a7c6185206cea70fb47772b04/src/update-feeds-loops/update-feeds-loops.ts#L153) overlap (but the logic of processing the same feed at the same time is low). It works well in practice and staggering here is much simpler - we only make an HTTP call, verify the data and save it to state.

I was thinking whether to shuffle the URLs before fetching them as per:
> We are making the Signed API calls always in the same order. It's likely that the later calls suffer from these timeouts more so we will likely be missing data for some Airnodes more than the others.

but same order works much better with staggering.

