### PR TITLE
Update renovate dependency reviewer

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -23,6 +23,6 @@
   "lockFileMaintenance": {
     "enabled": false
   },
-  "reviewers": ["aquarat"],
+  "reviewers": ["Siegrift"],
   "dependencyDashboard": false
 }


### PR DESCRIPTION
I think it makes more sense for me to handle the dependency updates - it's basically 0 effort anyway. I'll update the responsibilities in our tech documentation afterwards.