### PR TITLE
Temporarily disable signed data verification

### DIFF
--- a/src/data-fetcher-loop/signed-data-state.test.ts
+++ b/src/data-fetcher-loop/signed-data-state.test.ts
@@ -55,7 +55,8 @@ describe('signed data state', () => {
     expect(signedDataStateModule.verifySignedDataIntegrity(futureTestDataPoint)).toBeFalsy();
   });
 
-  it('checks the signature on signed data', async () => {
+  // eslint-disable-next-line jest/no-disabled-tests
+  it.skip('checks the signature on signed data', async () => {
     const templateId = generateRandomBytes(32);
     const timestamp = Math.floor((Date.now() + 60 * 60 * 1000) / 1000).toString();
     const airnode = ethers.Wallet.createRandom().address as Hex;

--- a/src/data-fetcher-loop/signed-data-state.ts
+++ b/src/data-fetcher-loop/signed-data-state.ts
@@ -51,7 +51,8 @@ const verifyTimestamp = (timestamp: number) => {
 };
 
 export const verifySignedDataIntegrity = (signedData: SignedData) => {
-  return verifyTimestamp(Number.parseInt(signedData.timestamp, 10)) && verifySignedData(signedData);
+  // TODO: Temporarily disable signed data verification.
+  return verifyTimestamp(Number.parseInt(signedData.timestamp, 10)) /* && verifySignedData(signedData) */;
 };
 
 export const saveSignedData = (signedData: SignedData) => {


### PR DESCRIPTION
Verifying signed data is a big bottleneck in Airseeker. With less chains used Airseeker should be able to handle the load - but to be sure, we might temporarily disable the signed data signature check. Note, that we only query the Nodary and API3 Signed APIs at the moment, which we can trust.

This should allow Airseeker to be much more performant until we resolve https://github.com/api3dao/airseeker-v2/issues/282 