### PR TITLE
Change coordinator IDs to ISO8601 format

### DIFF
--- a/src/data-fetcher-loop/data-fetcher-loop.test.ts
+++ b/src/data-fetcher-loop/data-fetcher-loop.test.ts
@@ -79,7 +79,11 @@ describe(dataFetcherLoopModule.runDataFetcher.name, () => {
       10_000
     );
     expect(logger.info).toHaveBeenCalledTimes(3);
-    expect(logger.info).toHaveBeenNthCalledWith(1, 'Fetching signed data.', { urlCount: 1, staggerTimeMs: 10_000 });
+    expect(logger.info).toHaveBeenNthCalledWith(
+      1,
+      'Fetching signed data.',
+      expect.objectContaining({ urlCount: 1, staggerTimeMs: 10_000 })
+    );
     expect(logger.info).toHaveBeenNthCalledWith(2, 'Fetched signed data from Signed API.', expect.any(Object));
     expect(logger.info).toHaveBeenNthCalledWith(
       3,

--- a/src/data-fetcher-loop/data-fetcher-loop.ts
+++ b/src/data-fetcher-loop/data-fetcher-loop.ts
@@ -4,7 +4,7 @@ import { uniq } from 'lodash';
 import { logger } from '../logger';
 import { getState } from '../state';
 import { type SignedDataRecord, signedApiResponseSchema, type SignedDataRecordEntry } from '../types';
-import { sleep } from '../utils';
+import { generateRandomId, sleep } from '../utils';
 
 import { purgeOldSignedData, saveSignedData } from './signed-data-state';
 
@@ -56,7 +56,7 @@ export const callSignedApi = async (url: string, timeout: number): Promise<Signe
 };
 
 export const runDataFetcher = async () => {
-  return logger.runWithContext({ dataFetcherCoordinatorId: new Date().toISOString() }, async () => {
+  return logger.runWithContext({ dataFetcherCoordinatorId: generateRandomId() }, async () => {
     const state = getState();
     const {
       config: { signedDataFetchInterval },
@@ -83,7 +83,7 @@ export const runDataFetcher = async () => {
 
     const urlCount = urls.length;
     const staggerTimeMs = signedDataFetchIntervalMs / urlCount;
-    logger.info('Fetching signed data.', { urlCount, staggerTimeMs });
+    logger.info('Fetching signed data.', { urlCount, staggerTimeMs, currentTime: new Date().toISOString() });
     const fetchResults = await Promise.all(
       urls.map(async (url, index) => {
         await sleep(staggerTimeMs * index);

--- a/src/data-fetcher-loop/data-fetcher-loop.ts
+++ b/src/data-fetcher-loop/data-fetcher-loop.ts
@@ -56,7 +56,7 @@ export const callSignedApi = async (url: string, timeout: number): Promise<Signe
 };
 
 export const runDataFetcher = async () => {
-  return logger.runWithContext({ dataFetcherCoordinatorId: Date.now().toString() }, async () => {
+  return logger.runWithContext({ dataFetcherCoordinatorId: new Date().toISOString() }, async () => {
     const state = getState();
     const {
       config: { signedDataFetchInterval },

--- a/src/update-feeds-loops/update-feeds-loops.test.ts
+++ b/src/update-feeds-loops/update-feeds-loops.test.ts
@@ -299,10 +299,11 @@ describe(updateFeedsLoopsModule.runUpdateFeeds.name, () => {
     });
     expect(logger.debug).toHaveBeenNthCalledWith(10, 'Fetching gas price and saving it to the state.');
 
-    expect(logger.info).toHaveBeenCalledTimes(3);
-    expect(logger.info).toHaveBeenNthCalledWith(1, 'Updating pending transaction info.', expect.anything());
+    expect(logger.info).toHaveBeenCalledTimes(4);
+    expect(logger.info).toHaveBeenNthCalledWith(1, 'Running update feeds loop.', expect.anything());
     expect(logger.info).toHaveBeenNthCalledWith(2, 'Updating pending transaction info.', expect.anything());
-    expect(logger.info).toHaveBeenNthCalledWith(3, 'Finished processing batches of active data feeds.', {
+    expect(logger.info).toHaveBeenNthCalledWith(3, 'Updating pending transaction info.', expect.anything());
+    expect(logger.info).toHaveBeenNthCalledWith(4, 'Finished processing batches of active data feeds.', {
       dataFeedUpdateFailures: 2,
       dataFeedUpdates: 0,
       skippedBatchesCount: 1,

--- a/src/update-feeds-loops/update-feeds-loops.ts
+++ b/src/update-feeds-loops/update-feeds-loops.ts
@@ -146,7 +146,7 @@ export const readActiveDataFeedBatch = async (
 
 export const runUpdateFeeds = async (providerName: string, chain: Chain, chainId: string) => {
   await logger.runWithContext(
-    { chainName: chain.alias, providerName, updateFeedsCoordinatorId: Date.now().toString() },
+    { chainName: chain.alias, providerName, updateFeedsCoordinatorId: new Date().toISOString() },
     async () => {
       // We do not expect this function to throw, but its possible that some execution path is incorrectly handled and we
       // want to process the error ourselves, for example log the error using the configured format.

--- a/src/update-feeds-loops/update-feeds-loops.ts
+++ b/src/update-feeds-loops/update-feeds-loops.ts
@@ -7,7 +7,7 @@ import type { Chain } from '../config/schema';
 import { fetchAndStoreGasPrice, initializeGasState } from '../gas-price';
 import { logger } from '../logger';
 import { getState, updateState } from '../state';
-import { sanitizeEthersError, sleep } from '../utils';
+import { generateRandomId, sanitizeEthersError, sleep } from '../utils';
 
 import {
   decodeActiveDataFeedCountResponse,
@@ -146,8 +146,10 @@ export const readActiveDataFeedBatch = async (
 
 export const runUpdateFeeds = async (providerName: string, chain: Chain, chainId: string) => {
   await logger.runWithContext(
-    { chainName: chain.alias, providerName, updateFeedsCoordinatorId: new Date().toISOString() },
+    { chainName: chain.alias, providerName, updateFeedsCoordinatorId: generateRandomId() },
     async () => {
+      logger.info(`Running update feeds loop.`, { currentTime: new Date().toISOString() });
+
       // We do not expect this function to throw, but its possible that some execution path is incorrectly handled and we
       // want to process the error ourselves, for example log the error using the configured format.
       const goRunUpdateFeeds = await go(async () => {

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -6,6 +6,7 @@ import {
   deriveSponsorWallet,
   deriveSponsorWalletFromSponsorAddressHash,
   encodeDapiName,
+  generateRandomId,
 } from './utils';
 
 describe(deriveSponsorWalletFromSponsorAddressHash.name, () => {
@@ -85,4 +86,10 @@ test('ethers compatibility for Wallet.fromMnemonic', () => {
   );
 
   expect(wallet.address).toBe('0xE1f7E4662F92e5DaDB9529Efb2EE61ec63b028e3');
+});
+
+describe(generateRandomId.name, () => {
+  it('generates an ID', () => {
+    expect(generateRandomId()).toMatch(/^[\da-f]{64}$/); // There is no 0x prefix.
+  });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,5 @@
+import { randomBytes } from 'node:crypto';
+
 import { type Address, deriveWalletPathFromSponsorAddress, type Hex } from '@api3/commons';
 import { type ErrorCode, ethers, type EthersError } from 'ethers';
 
@@ -91,3 +93,5 @@ export const sanitizeEthersError = (error: Error) => {
   // sources, the short message should always be defined.
   return new SanitizedErrorsError(ethersError.code, ethersError.shortMessage);
 };
+
+export const generateRandomId = () => randomBytes(32).toString('hex');


### PR DESCRIPTION
Closes https://github.com/api3dao/airseeker-v2/issues/280

## Rationale

This should make the IDs easy to differentiate from each other, while being "unique enough". I don't see a huge need for UUIDs.