### PR TITLE
Prevent gas price scaling if data feed was updated since the first update tx

### DIFF
--- a/src/gas-price/gas-price.test.ts
+++ b/src/gas-price/gas-price.test.ts
@@ -228,6 +228,7 @@ describe(getRecommendedGasPrice.name, () => {
           [dataFeedId]: {
             consecutivelyUpdatableCount: 2,
             firstUpdatableTimestamp: timestampMock - 60, // The feed requires update for 1 minute.
+            onChainTimestamp: BigInt(timestampMock - 65),
           },
         },
       };
@@ -261,6 +262,7 @@ describe(getRecommendedGasPrice.name, () => {
           [dataFeedId]: {
             consecutivelyUpdatableCount: 12,
             firstUpdatableTimestamp: timestampMock - 60 * 60, // The feed requires update for 1 hour.
+            onChainTimestamp: BigInt(timestampMock - 60 * 60 + 5),
           },
         },
       };
@@ -299,6 +301,7 @@ describe(getRecommendedGasPrice.name, () => {
           [dataFeedId]: {
             consecutivelyUpdatableCount: 12,
             firstUpdatableTimestamp: timestampMock - 60 * 60, // The feed requires update for 1 hour.
+            onChainTimestamp: BigInt(timestampMock - 60 * 60 + 5),
           },
         },
       };
@@ -340,10 +343,12 @@ describe(getRecommendedGasPrice.name, () => {
           [dataFeedId]: {
             consecutivelyUpdatableCount: 2,
             firstUpdatableTimestamp: timestampMock - 59,
+            onChainTimestamp: BigInt(timestampMock - 65),
           },
           [anotherDataFeedId]: {
             consecutivelyUpdatableCount: 2,
             firstUpdatableTimestamp: timestampMock - 60,
+            onChainTimestamp: BigInt(timestampMock - 65),
           },
           [yetAnotherDataFeedId]: null,
         },

--- a/src/state/state.test.ts
+++ b/src/state/state.test.ts
@@ -23,6 +23,7 @@ const stateMock: State = {
           [beaconId]: {
             consecutivelyUpdatableCount: 1,
             firstUpdatableTimestamp: timestampMock,
+            onChainTimestamp: 1_696_930_907n,
           },
         },
       },

--- a/src/state/state.ts
+++ b/src/state/state.ts
@@ -16,6 +16,11 @@ export interface PendingTransactionInfo {
   // The count of how many consecutive updates are required for this data feed. This is used to determine if the
   // transaction is a retry or not.
   consecutivelyUpdatableCount: number;
+  // The on-chain timestamp of the last pending transaction. As a note, in a volatile market it is possible that we
+  // submit an update transaction and in the next run we detect that feed needs an update again, even though the feed
+  // was updated during this time (either by the previous transaction or by other Airseeker). The on-chain timestamp
+  // aims to detect this case, so that we avoid scaling the gas price for this subsequent update.
+  onChainTimestamp: bigint;
 }
 
 export interface State {

--- a/src/update-feeds-loops/pending-transaction-info.test.ts
+++ b/src/update-feeds-loops/pending-transaction-info.test.ts
@@ -20,6 +20,7 @@ describe(setPendingTransactionInfo.name, () => {
     const pendingTransactionInfo: PendingTransactionInfo = {
       consecutivelyUpdatableCount: 1,
       firstUpdatableTimestamp: timestampMock,
+      onChainTimestamp: 1_696_930_907n,
     };
 
     setPendingTransactionInfo(chainId, providerName, sponsorWalletAddress, dataFeedId, pendingTransactionInfo);


### PR DESCRIPTION
Closes https://github.com/api3dao/airseeker-v2/issues/295

## Rationale

The idea is to persist the on-chain timestamp of the data feed at the time of the transaction. When Airseeker sees that the feed requires consecutive update, we check whether the timestamp has changed. If the timestamp has changed, we know the feed was updated - either by the previous transaction or other Airseeker update, but the update source does not really matter. In that case, we reset the pending transaction info and consider the next update as original.

As a note, we track pending transaction info per sponsor per data feed to support different wallet derivation schemes, but [updates are data feed specific](https://api3workspace.slack.com/archives/C05TQPT7PNJ/p1713948371457569?thread_ts=1713458319.193379&cid=C05TQPT7PNJ). So if there are pending transactions for the same data feed from two sponsor wallets, their pending transaction info should be reset if the feed was updated. The current scheme handles that implicitly.

