### PR TITLE
Enable Renovate `automerge`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,19 +10,20 @@
       "matchDepTypes": ["devDependencies"],
       "matchUpdateTypes": ["patch", "minor"],
       "schedule": ["before 4am on Monday"],
-      "groupName": "non-major-dev-dependencies"
+      "groupName": "non-major-dev-dependencies",
+      "automerge": true
     },
     {
       "matchDepTypes": ["dependencies"],
       "matchUpdateTypes": ["patch", "minor"],
       "schedule": ["before 4am on Monday"],
-      "groupName": "non-major-dependencies"
+      "groupName": "non-major-dependencies",
+      "automerge": true
     }
   ],
   "rangeStrategy": "bump",
   "lockFileMaintenance": {
-    "enabled": true,
-    "automerge": true
+    "enabled": true
   },
   "reviewers": ["bdrhn9"],
   "dependencyDashboard": false

--- a/renovate.json
+++ b/renovate.json
@@ -23,7 +23,7 @@
   ],
   "rangeStrategy": "bump",
   "lockFileMaintenance": {
-    "enabled": true
+    "enabled": false
   },
   "reviewers": ["bdrhn9"],
   "dependencyDashboard": false

--- a/renovate.json
+++ b/renovate.json
@@ -21,8 +21,9 @@
   ],
   "rangeStrategy": "bump",
   "lockFileMaintenance": {
-    "enabled": false
+    "enabled": true,
+    "automerge": true
   },
-  "reviewers": ["Siegrift"],
+  "reviewers": ["Siegrift", "aquarat", "bdrhn9"],
   "dependencyDashboard": false
 }

--- a/renovate.json
+++ b/renovate.json
@@ -24,6 +24,6 @@
     "enabled": true,
     "automerge": true
   },
-  "reviewers": ["Siegrift", "aquarat", "bdrhn9"],
+  "reviewers": ["bdrhn9"],
   "dependencyDashboard": false
 }


### PR DESCRIPTION
As requested by @Siegrift this enables Remnovate `automerge` for patch and minor dependency releases.

Adding Siegrift because he requested the change, bdrhn9 because AFAIK he's the major user of this repository and hiletmis because he's familiar with Renovate.

Closes https://github.com/api3dao/airseeker/issues/365