### PR TITLE
Update contract references

### DIFF
--- a/config/configuration.md
+++ b/config/configuration.md
@@ -120,8 +120,7 @@ A record of contract addresses used by Airseeker.
 
 ##### `Api3ServerV1` _(optional)_
 
-The address of the Api3ServerV1 contract. If not specified, the address is loaded from the
-[Airnode protocol v1](https://github.com/api3dao/airnode-protocol-v1) repository.
+The address of the Api3ServerV1 contract. If not specified, the address is loaded from `@api3/contracts`.
 
 ##### `AirseekerRegistry`
 

--- a/local-test-configuration/monitoring/index.html
+++ b/local-test-configuration/monitoring/index.html
@@ -778,7 +778,7 @@
     };
 
     const decodeUpdateParameters = (updateParameters) => {
-      // https://github.com/api3dao/airnode-protocol-v1/blob/5f861715749e182e334c273d6a52c4f2560c7994/contracts/api3-server-v1/extensions/BeaconSetUpdatesWithPsp.sol#L122
+      // https://github.com/api3dao/contracts/blob/4592f5c4802f7cf2585884fc641a1e89937bfd9c/contracts/api3-server-v1/Api3MarketV2.sol#L974
       const [deviationThresholdInPercentage, deviationReference, heartbeatInterval] =
         ethers.AbiCoder.defaultAbiCoder().decode(['uint256', 'int224', 'uint256'], updateParameters);
 

--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -76,7 +76,7 @@ describe('chains schema', () => {
     });
   });
 
-  it('uses the contract address from airnode-protocol-v1', () => {
+  it('uses the contract address from the package @api3/contracts', () => {
     const chains = {
       '1': {
         providers: {

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -18,7 +18,7 @@ export type Provider = z.infer<typeof providerSchema>;
 
 export const optionalContractsSchema = z
   .object({
-    // If unspecified, Api3ServerV1 will be loaded from "airnode-protocol-v1" or error out during validation.
+    // If unspecified, Api3ServerV1 will be loaded from the package @api3/contracts or error out during validation.
     Api3ServerV1: addressSchema.optional(),
     AirseekerRegistry: addressSchema,
   })
@@ -59,7 +59,7 @@ export const gasSettingsSchema = z
 
 export type GasSettings = z.infer<typeof gasSettingsSchema>;
 
-// Contracts are optional. If unspecified, they will be loaded from "airnode-protocol-v1" or error out during
+// Contracts are optional. If unspecified, they will be loaded from the package @api3/contracts or error out during
 // validation. We need a chain ID from parent schema to load the contracts.
 export const optionalChainSchema = z
   .object({
@@ -84,7 +84,7 @@ const chainSchema = optionalChainSchema
 
 export type Chain = z.infer<typeof chainSchema>;
 
-// Ensure that the contracts are loaded from "airnode-protocol-v1" if not specified.
+// Ensure that the contracts are loaded from the package @api3/contracts if not specified.
 export const chainsSchema = z
   .record(optionalChainSchema)
   .superRefine((chains, ctx) => {

--- a/src/update-feeds-loops/contracts.ts
+++ b/src/update-feeds-loops/contracts.ts
@@ -95,7 +95,7 @@ export interface DecodedUpdateParameters {
 }
 
 export const decodeUpdateParameters = (updateParameters: string): DecodedUpdateParameters => {
-  // https://github.com/api3dao/airnode-protocol-v1/blob/5f861715749e182e334c273d6a52c4f2560c7994/contracts/api3-server-v1/extensions/BeaconSetUpdatesWithPsp.sol#L122
+  // // https://github.com/api3dao/contracts/blob/4592f5c4802f7cf2585884fc641a1e89937bfd9c/contracts/api3-server-v1/Api3MarketV2.sol#L974
   const [deviationThresholdInPercentage, deviationReference, heartbeatInterval] =
     ethers.AbiCoder.defaultAbiCoder().decode(['uint256', 'int224', 'uint256'], updateParameters);
   // 2 characters for the '0x' preamble + 3 parameters, 32 * 2 hexadecimals for 32 bytes each

--- a/src/update-feeds-loops/get-updatable-feeds.test.ts
+++ b/src/update-feeds-loops/get-updatable-feeds.test.ts
@@ -14,7 +14,7 @@ import { getUpdatableFeeds } from './get-updatable-feeds';
 
 const ONE_PERCENT = BigInt(Number(HUNDRED_PERCENT) / 100);
 
-// https://github.com/api3dao/airnode-protocol-v1/blob/fa95f043ce4b50e843e407b96f7ae3edcf899c32/contracts/api3-server-v1/DataFeedServer.sol#L132
+// https://github.com/api3dao/contracts/blob/4592f5c4802f7cf2585884fc641a1e89937bfd9c/contracts/api3-server-v1/DataFeedServer.sol#L132
 const encodeBeaconValue = (numericValue: string) => {
   const numericValueAsBigNumber = BigInt(numericValue);
 

--- a/src/update-feeds-loops/get-updatable-feeds.ts
+++ b/src/update-feeds-loops/get-updatable-feeds.ts
@@ -104,12 +104,12 @@ export const getUpdatableFeeds = (
       // on-chain value. There are two cases:
       // 1. Data feed is a beacon - We need to make sure the off-chain data
       //    updates the feed. This requires timestamp to change. See:
-      //    https://github.com/api3dao/airnode-protocol-v1/blob/65a77cdc23dc5434e143357a506327b9f0ccb7ef/contracts/api3-server-v1/DataFeedServer.sol#L120
+      //    https://github.com/api3dao/contracts/blob/4592f5c4802f7cf2585884fc641a1e89937bfd9c/contracts/api3-server-v1/DataFeedServer.sol#L120
       const isValidBeaconUpdate = !isBeaconSet && newDataFeedTimestamp !== dataFeedTimestamp;
 
       // 2. Data feed is a beacon set - We need to make sure that the beacon set will change. The contract requires the
       //    beacon set value or timestamp to change. See:
-      //    https://github.com/api3dao/airnode-protocol-v1/blob/65a77cdc23dc5434e143357a506327b9f0ccb7ef/contracts/api3-server-v1/DataFeedServer.sol#L54
+      //    https://github.com/api3dao/contracts/blob/4592f5c4802f7cf2585884fc641a1e89937bfd9c/contracts/api3-server-v1/DataFeedServer.sol#L54
       // Note, that the beacon set value/timestamp is computed as median, so single beacon update may not result in a beacon set update.
       const isValidBeaconSetUpdate =
         isBeaconSet && (newDataFeedValue !== dataFeedValue || newDataFeedTimestamp !== dataFeedTimestamp);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -78,7 +78,7 @@ export const deriveSponsorWallet = (sponsorWalletMnemonic: string, sponsorParams
 export const multiplyBigNumber = (bigNumber: bigint, multiplier: number) =>
   (bigNumber * BigInt(Math.round(multiplier * 100))) / 100n;
 
-// https://github.com/api3dao/airnode-protocol-v1/blob/fa95f043ce4b50e843e407b96f7ae3edcf899c32/contracts/api3-server-v1/DataFeedServer.sol#L132
+// https://github.com/api3dao/contracts/blob/4592f5c4802f7cf2585884fc641a1e89937bfd9c/contracts/api3-server-v1/DataFeedServer.sol#L132
 export const decodeBeaconValue = (encodedBeaconValue: string) => {
   const decodedBeaconValue = BigInt(ethers.AbiCoder.defaultAbiCoder().decode(['int256'], encodedBeaconValue)[0]);
   if (decodedBeaconValue > INT224_MAX || decodedBeaconValue < INT224_MIN) {


### PR DESCRIPTION
Closes #496.

The following references remain unchanged and still point to `airnode-protocol-v1` because no equivalent is available in the api3dao/contracts repository:
* https://github.com/api3dao/airseeker/blob/17dc5b6c291faca2c73c120876e89ac2fa34a68a/src/deviation-check/deviation-check.test.ts#L163
* https://github.com/api3dao/airseeker/blob/17dc5b6c291faca2c73c120876e89ac2fa34a68a/src/deviation-check/deviation-check.ts#L47