### PR TITLE
Add `contents: write` permission to release workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -93,6 +93,7 @@ jobs:
         node-version: [20]
     permissions:
       id-token: write
+      contents: write
     steps:
       - name: Clone repo
         uses: actions/checkout@v5


### PR DESCRIPTION
### Problem
The release workflow failed during tag creation with the following error: https://github.com/api3dao/airseeker/actions/runs/20232703249/job/58123311904#step:10:29

This issue was unexpected as the workflow previously functioned without problems.

### Solution
After debugging in a personal repository, the issue was identified as missing `contents: write` permission. This permission has been added to the `tag-and-release` job to enable pushing tags to the repository.