### PR TITLE
Update local test configuration

### DIFF
--- a/local-test-configuration/README.md
+++ b/local-test-configuration/README.md
@@ -26,13 +26,13 @@ assets from the Nodary API to see Airseeker updates.
 - Start Signed API 1 on port `4001` (in a separate terminal):
 
 ```sh
-docker run --publish 4001:80 -it --init --volume $(pwd)/local-test-configuration/signed-api-1:/app/config --env-file ./local-test-configuration/signed-api-1/.env --rm --memory=256m api3/signed-api:v4.0.1
+docker run --publish 4001:80 -it --init --volume $(pwd)/local-test-configuration/signed-api-1:/app/config --env-file ./local-test-configuration/signed-api-1/.env --rm --memory=256m api3/signed-api:v4.1.0
 ```
 
 - Start Signed API 2 on port `4002` (in a separate terminal):
 
 ```sh
-docker run --publish 4002:80 -it --init --volume $(pwd)/local-test-configuration/signed-api-2:/app/config --env-file ./local-test-configuration/signed-api-2/.env --rm --memory=256m api3/signed-api:v4.0.1
+docker run --publish 4002:80 -it --init --volume $(pwd)/local-test-configuration/signed-api-2:/app/config --env-file ./local-test-configuration/signed-api-2/.env --rm --memory=256m api3/signed-api:v4.1.0
 ```
 
 You can go to `http://localhost:4001/` and `http://localhost:4002/` to see the Signed API 1 and 2 respectively.
@@ -40,13 +40,13 @@ You can go to `http://localhost:4001/` and `http://localhost:4002/` to see the S
 - Start Airnode feed 1 (in a separate terminal):
 
 ```sh
-docker run -it --init --volume $(pwd)/local-test-configuration/airnode-feed-1:/app/config --network host --env-file ./local-test-configuration/airnode-feed-1/.env --rm --memory=256m api3/airnode-feed:v4.0.1
+docker run -it --init --volume $(pwd)/local-test-configuration/airnode-feed-1:/app/config --network host --env-file ./local-test-configuration/airnode-feed-1/.env --rm --memory=256m api3/airnode-feed:v4.1.0
 ```
 
 - Start Airnode feed 2 (in a separate terminal):
 
 ```sh
-docker run -it --init --volume $(pwd)/local-test-configuration/airnode-feed-2:/app/config --network host --env-file ./local-test-configuration/airnode-feed-2/.env --rm --memory=256m api3/airnode-feed:v4.0.1
+docker run -it --init --volume $(pwd)/local-test-configuration/airnode-feed-2:/app/config --network host --env-file ./local-test-configuration/airnode-feed-2/.env --rm --memory=256m api3/airnode-feed:v4.1.0
 ```
 
 - Start Hardhat node (in a separate terminal):

--- a/local-test-configuration/airnode-feed-1/airnode-feed.json
+++ b/local-test-configuration/airnode-feed-1/airnode-feed.json
@@ -50,8 +50,7 @@
           }
         },
         "paths": {
-          "/feed/latest": { "get": { "parameters": [{ "in": "query", "name": "name" }] } },
-          "/feed/latestV2": { "get": { "parameters": [{ "in": "query", "name": "names" }] } }
+          "/feed/latest": { "get": { "parameters": [{ "in": "query", "name": "name" }] } }
         },
         "servers": [{ "url": "https://api.nodary.io" }],
         "security": { "NodarySecurityScheme1ApiKey": [] }
@@ -60,8 +59,8 @@
         {
           "fixedOperationParameters": [],
           "name": "feed",
-          "operation": { "method": "get", "path": "/feed/latestV2" },
-          "parameters": [{ "name": "name", "operationParameter": { "in": "query", "name": "names" } }],
+          "operation": { "method": "get", "path": "/feed/latest" },
+          "parameters": [{ "name": "name", "operationParameter": { "in": "query", "name": "name" } }],
           "reservedParameters": [
             { "name": "_type", "fixed": "int256" },
             { "name": "_times", "fixed": "1000000000000000000" }

--- a/local-test-configuration/airnode-feed-1/airnode-feed.json
+++ b/local-test-configuration/airnode-feed-1/airnode-feed.json
@@ -91,7 +91,7 @@
     }
   ],
   "nodeSettings": {
-    "nodeVersion": "4.0.1",
+    "nodeVersion": "4.1.0",
     "airnodeWalletMnemonic": "${AIRNODE_WALLET_MNEMONIC}",
     "stage": "local-example"
   }

--- a/local-test-configuration/airnode-feed-2/airnode-feed.json
+++ b/local-test-configuration/airnode-feed-2/airnode-feed.json
@@ -50,8 +50,7 @@
           }
         },
         "paths": {
-          "/feed/latest": { "get": { "parameters": [{ "in": "query", "name": "name" }] } },
-          "/feed/latestV2": { "get": { "parameters": [{ "in": "query", "name": "names" }] } }
+          "/feed/latest": { "get": { "parameters": [{ "in": "query", "name": "name" }] } }
         },
         "servers": [{ "url": "https://api.nodary.io" }],
         "security": { "NodarySecurityScheme1ApiKey": [] }
@@ -60,8 +59,8 @@
         {
           "fixedOperationParameters": [],
           "name": "feed",
-          "operation": { "method": "get", "path": "/feed/latestV2" },
-          "parameters": [{ "name": "name", "operationParameter": { "in": "query", "name": "names" } }],
+          "operation": { "method": "get", "path": "/feed/latest" },
+          "parameters": [{ "name": "name", "operationParameter": { "in": "query", "name": "name" } }],
           "reservedParameters": [
             { "name": "_type", "fixed": "int256" },
             { "name": "_times", "fixed": "1000000000000000000" }

--- a/local-test-configuration/airnode-feed-2/airnode-feed.json
+++ b/local-test-configuration/airnode-feed-2/airnode-feed.json
@@ -91,7 +91,7 @@
     }
   ],
   "nodeSettings": {
-    "nodeVersion": "4.0.1",
+    "nodeVersion": "4.1.0",
     "airnodeWalletMnemonic": "${AIRNODE_WALLET_MNEMONIC}",
     "stage": "local-example"
   }

--- a/local-test-configuration/signed-api-1/signed-api.json
+++ b/local-test-configuration/signed-api-1/signed-api.json
@@ -11,5 +11,5 @@
     { "address": "0xaC0653E412acAE526Da3a33af0135205A34E21AF", "authTokens": null, "isCertified": true }
   ],
   "stage": "signed-api-1",
-  "version": "4.0.1"
+  "version": "4.1.0"
 }

--- a/local-test-configuration/signed-api-2/signed-api.json
+++ b/local-test-configuration/signed-api-2/signed-api.json
@@ -11,5 +11,5 @@
     { "address": "0x2Bf0dddA8Daa1C3C0Fae9e85866807A1C2D601B7", "authTokens": null, "isCertified": false }
   ],
   "stage": "signed-api-2",
-  "version": "4.0.1"
+  "version": "4.1.0"
 }


### PR DESCRIPTION
## Changes

- **Bump versions from v4.0.1 to v4.1.0**: Updated node versions in Signed API configs, Airnode feed configs, and Docker run commands in the README.
- **Remove deprecated Nodary endpoint**: Replaced `/feed/latestV2` with `/feed/latest` in both Airnode feed configurations.
