### PR TITLE
Migrate from @api3/promise-utils to @api3/commons

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,10 +36,9 @@
     "tsc": "tsc --project ."
   },
   "dependencies": {
-    "@api3/commons": "^1.2.0",
+    "@api3/commons": "^1.3.0",
     "@api3/contracts": "38.3.0",
     "@api3/eslint-plugin-commons": "^3.1.1",
-    "@api3/promise-utils": "^0.4.0",
     "dotenv": "^17.4.2",
     "ethers": "^6.17.0",
     "immer": "^11.1.15",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,17 +9,14 @@ importers:
   .:
     dependencies:
       '@api3/commons':
-        specifier: ^1.2.0
-        version: 1.2.0
+        specifier: ^1.3.0
+        version: 1.3.0
       '@api3/contracts':
         specifier: 38.3.0
         version: 38.3.0(typescript@5.9.3)
       '@api3/eslint-plugin-commons':
         specifier: ^3.1.1
         version: 3.1.1(eslint@8.57.1)(jest@29.7.0(@types/node@24.13.3)(ts-node@10.9.2(@types/node@24.13.3)(typescript@5.9.3)))(prettier@3.9.6)(typescript@5.9.3)
-      '@api3/promise-utils':
-        specifier: ^0.4.0
-        version: 0.4.0
       dotenv:
         specifier: ^17.4.2
         version: 17.4.2
@@ -123,9 +120,9 @@ packages:
   '@api3/airnode-abi@0.15.0':
     resolution: {integrity: sha512-MMq5pBkXFA6QkqTLCWWygGXz7TdmYe8dFbgQs9IEmp0Av05U7min6rottBcRhjpOEo8LXT8InkIbdmql+UaS3A==}
 
-  '@api3/commons@1.2.0':
-    resolution: {integrity: sha512-9Bovi9tWpGVXxgkXC7YOeBXpiyWo2l8RmkHgfA9GAB4G3vZny+a8WHSQeWLNnJ4Zig7W9JTf2peExEAhhjsLjA==}
-    engines: {node: '>=18.14.0'}
+  '@api3/commons@1.3.0':
+    resolution: {integrity: sha512-2LqiFSa4l+1LwyfJSTpHRrRWBfDCL9xYlcRGO+RlAoRQz9/2Ym55iwuLpsvO2jQt4npNvsEUaOfFIpAohXjJIg==}
+    engines: {node: '>=18.20.8'}
 
   '@api3/contracts@38.3.0':
     resolution: {integrity: sha512-vscJip1KOh39nSBAPUiyZRKzfknINBkelF+giFhfAxpjZrWS/kgXYQaMMQAG6ZDnI3LXtKfQ2aQdu8mFHlNg+Q==}
@@ -140,9 +137,6 @@ packages:
 
   '@api3/ois@3.0.0':
     resolution: {integrity: sha512-scqcvBOBsptgW3rsTLxQSlTA51W1Fr0YpvyKg2JDS2zTDeGNg1gWx9A3tW6fTM4cj57VnowPgj/ZyxQ7w1Ch0Q==}
-
-  '@api3/promise-utils@0.4.0':
-    resolution: {integrity: sha512-+8fcNjjQeQAuuSXFwu8PMZcYzjwjDiGYcMUfAQ0lpREb1zHonwWZ2N0B9h/g1cvWzg9YhElbeb/SyhCrNm+b/A==}
 
   '@babel/code-frame@7.29.7':
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
@@ -4698,10 +4692,9 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@api3/commons@1.2.0':
+  '@api3/commons@1.3.0':
     dependencies:
       '@api3/ois': 3.0.0
-      '@api3/promise-utils': 0.4.0
       '@octokit/rest': 20.1.2
       axios: 1.18.1
       dotenv: 17.4.2
@@ -4763,8 +4756,6 @@ snapshots:
     dependencies:
       lodash: 4.18.1
       zod: 4.4.3
-
-  '@api3/promise-utils@0.4.0': {}
 
   '@babel/code-frame@7.29.7':
     dependencies:

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -2,11 +2,11 @@ import { join } from 'node:path';
 import { cwd } from 'node:process';
 
 import {
+  goSync,
   interpolateSecretsIntoConfig,
   loadConfig as loadConfigCommons,
   loadSecrets as loadSecretsCommons,
 } from '@api3/commons';
-import { goSync } from '@api3/promise-utils';
 
 import { configSchema } from './schema';
 

--- a/src/data-fetcher-loop/signed-data-verifier.ts
+++ b/src/data-fetcher-loop/signed-data-verifier.ts
@@ -1,5 +1,4 @@
-import { deriveBeaconId } from '@api3/commons';
-import { goSync } from '@api3/promise-utils';
+import { deriveBeaconId, goSync } from '@api3/commons';
 import { ethers } from 'ethers';
 
 import type { SignedData, SignedDataRecordEntry } from '../types';

--- a/src/gas-price/gas-price.ts
+++ b/src/gas-price/gas-price.ts
@@ -1,5 +1,4 @@
-import type { Address, Hex } from '@api3/commons';
-import { go } from '@api3/promise-utils';
+import { go, type Address, type Hex } from '@api3/commons';
 import { getBigInt, type ethers } from 'ethers';
 import { maxBy, minBy, remove } from 'lodash';
 

--- a/src/heartbeat-loop/heartbeat-loop.ts
+++ b/src/heartbeat-loop/heartbeat-loop.ts
@@ -1,5 +1,4 @@
-import { createSha256Hash, serializePlainObject } from '@api3/commons';
-import { go } from '@api3/promise-utils';
+import { createSha256Hash, go, serializePlainObject } from '@api3/commons';
 import { ethers } from 'ethers';
 
 import { loadRawConfig } from '../config';

--- a/src/update-feeds-loops/contracts.ts
+++ b/src/update-feeds-loops/contracts.ts
@@ -1,10 +1,9 @@
-import { deriveBeaconId, type Address, type Hex } from '@api3/commons';
+import { deriveBeaconId, go, type Address, type Hex } from '@api3/commons';
 import {
   type AirseekerRegistry,
   AirseekerRegistry__factory as AirseekerRegistryFactory,
   Api3ServerV1__factory as Api3ServerV1Factory,
 } from '@api3/contracts';
-import { go } from '@api3/promise-utils';
 import { ethers } from 'ethers';
 import { zip } from 'lodash';
 

--- a/src/update-feeds-loops/gas-estimation.ts
+++ b/src/update-feeds-loops/gas-estimation.ts
@@ -1,5 +1,5 @@
+import { go } from '@api3/commons';
 import type { Api3ServerV1 } from '@api3/contracts';
-import { go } from '@api3/promise-utils';
 
 import { logger } from '../logger';
 import { sanitizeEthersError } from '../utils';

--- a/src/update-feeds-loops/submit-transactions.ts
+++ b/src/update-feeds-loops/submit-transactions.ts
@@ -1,6 +1,5 @@
-import type { Address, Hex } from '@api3/commons';
+import { go, type Address, type Hex } from '@api3/commons';
 import type { Api3ServerV1 } from '@api3/contracts';
-import { go } from '@api3/promise-utils';
 import { type EthersError, ethers } from 'ethers';
 
 import { getRecommendedGasPrice } from '../gas-price';

--- a/src/update-feeds-loops/update-feeds-loops.ts
+++ b/src/update-feeds-loops/update-feeds-loops.ts
@@ -1,5 +1,5 @@
+import { go } from '@api3/commons';
 import type { AirseekerRegistry } from '@api3/contracts';
-import { go } from '@api3/promise-utils';
 import type { ethers } from 'ethers';
 import { isError, range, set, size, uniq } from 'lodash';
 


### PR DESCRIPTION
As a part of https://github.com/api3dao/internal-operations/issues/2057.

`@api3/promise-utils` is deprecated. `@api3/commons` vendored `go`/`goSync` in 1.3.0, so they now come from there.
